### PR TITLE
Fixed input validation for sorts

### DIFF
--- a/src/algo/BubbleSort.js
+++ b/src/algo/BubbleSort.js
@@ -136,7 +136,7 @@ export default class BubbleSort extends Algorithm {
 		this.arrayData = params
 			.split(',')
 			.map(Number)
-			.filter(x => x)
+			.filter(x => !Number.isNaN(x))
 			.slice(0, 18);
 		const length = this.arrayData.length;
 		const elemCounts = new Map();
@@ -172,7 +172,13 @@ export default class BubbleSort extends Algorithm {
 				ypos
 			);
 		}
-		this.cmd(act.createHighlightCircle, this.iPointerID, '#0000FF', ARRAY_START_X, ARRAY_START_Y);
+		this.cmd(
+			act.createHighlightCircle,
+			this.iPointerID,
+			'#0000FF',
+			ARRAY_START_X,
+			ARRAY_START_Y
+		);
 		this.cmd(act.setHighlight, this.iPointerID, 1);
 		this.cmd(
 			act.createHighlightCircle,

--- a/src/algo/CocktailSort.js
+++ b/src/algo/CocktailSort.js
@@ -135,7 +135,7 @@ export default class CocktailSort extends Algorithm {
 		this.arrayData = params
 			.split(',')
 			.map(Number)
-			.filter(x => x)
+			.filter(x => !Number.isNaN(x))
 			.slice(0, 18);
 		this.displayData = new Array(this.arrayData.length);
 		const length = this.arrayData.length;
@@ -173,7 +173,13 @@ export default class CocktailSort extends Algorithm {
 				ypos
 			);
 		}
-		this.cmd(act.createHighlightCircle, this.iPointerID, '#0000FF', ARRAY_START_X, ARRAY_START_Y);
+		this.cmd(
+			act.createHighlightCircle,
+			this.iPointerID,
+			'#0000FF',
+			ARRAY_START_X,
+			ARRAY_START_Y
+		);
 		this.cmd(act.setHighlight, this.iPointerID, 1);
 		this.cmd(
 			act.createHighlightCircle,

--- a/src/algo/Heap.js
+++ b/src/algo/Heap.js
@@ -29,7 +29,7 @@ import Algorithm, {
 	addDivisorToAlgorithmBar,
 	addGroupToAlgorithmBar,
 	addLabelToAlgorithmBar,
-	addRadioButtonGroupToAlgorithmBar
+	addRadioButtonGroupToAlgorithmBar,
 } from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
 
@@ -146,10 +146,12 @@ export default class Heap extends Algorithm {
 
 		const verticalGroup = addGroupToAlgorithmBar(false);
 
-		addLabelToAlgorithmBar('Comma separated list (e.g. "3,1,2", max 31 elements)', verticalGroup);
+		addLabelToAlgorithmBar(
+			'Comma separated list (e.g. "3,1,2", max 31 elements)',
+			verticalGroup
+		);
 
 		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
-
 
 		this.buildHeapField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.buildHeapField.onkeydown = this.returnSubmit(
@@ -394,11 +396,7 @@ export default class Heap extends Algorithm {
 		this.cmd(act.setText, this.descriptLabel1, '');
 
 		if (this.currentHeapSize === 0) {
-			this.cmd(
-				act.setText,
-				this.descriptLabel1,
-				'Heap is empty, cannot dequeue'
-			);
+			this.cmd(act.setText, this.descriptLabel1, 'Heap is empty, cannot dequeue');
 			return this.commands;
 		}
 
@@ -437,7 +435,7 @@ export default class Heap extends Algorithm {
 		this.arrayData = params
 			.split(',') // Split on commas
 			.map(Number) // Map to numbers (to remove invalid characters)
-			.filter(x => x) // Remove stuff that was invalid
+			.filter(x => !Number.isNaN(x)) // Remove stuff that was invalid
 			.slice(0, 31) // Get first 31 numbers
 			.map(String); // Map back to strings
 		this.arrayData.unshift(0); // Add a 0 to start of array

--- a/src/algo/InsertionSort.js
+++ b/src/algo/InsertionSort.js
@@ -118,7 +118,7 @@ export default class InsertionSort extends Algorithm {
 		this.arrayData = params
 			.split(',')
 			.map(Number)
-			.filter(x => x)
+			.filter(x => !Number.isNaN(x))
 			.slice(0, 18);
 		this.displayData = new Array(this.arrayData.length);
 		const length = this.arrayData.length;
@@ -155,7 +155,13 @@ export default class InsertionSort extends Algorithm {
 				ypos
 			);
 		}
-		this.cmd(act.createHighlightCircle, this.iPointerID, '#0000FF', ARRAY_START_X, ARRAY_START_Y);
+		this.cmd(
+			act.createHighlightCircle,
+			this.iPointerID,
+			'#0000FF',
+			ARRAY_START_X,
+			ARRAY_START_Y
+		);
 		this.cmd(act.setHighlight, this.iPointerID, 1);
 		this.cmd(
 			act.createHighlightCircle,

--- a/src/algo/LSDRadix.js
+++ b/src/algo/LSDRadix.js
@@ -145,7 +145,7 @@ export default class LSDRadix extends Algorithm {
 		this.arrayData = params
 			.split(',')
 			.map(Number)
-			.filter(x => x)
+			.filter(x => !Number.isNaN(x))
 			.slice(0, 9);
 		const length = this.arrayData.length;
 		const elemCounts = new Map();
@@ -215,7 +215,13 @@ export default class LSDRadix extends Algorithm {
 			INFO_LABEL_Y,
 			0
 		);
-		this.cmd(act.createHighlightCircle, this.iPointerID, '#FF0000', ARRAY_START_X, ARRAY_START_Y);
+		this.cmd(
+			act.createHighlightCircle,
+			this.iPointerID,
+			'#FF0000',
+			ARRAY_START_X,
+			ARRAY_START_Y
+		);
 		this.cmd(act.setHighlight, this.iPointerID, 1);
 		this.cmd(
 			act.createHighlightCircle,

--- a/src/algo/MergeSort.js
+++ b/src/algo/MergeSort.js
@@ -138,7 +138,7 @@ export default class MergeSort extends Algorithm {
 		this.arrayData = params
 			.split(',')
 			.map(Number)
-			.filter(x => x)
+			.filter(x => !Number.isNaN(x))
 			.slice(0, 12);
 		this.displayData = new Array(this.arrayData.length);
 

--- a/src/algo/QuickSelect.js
+++ b/src/algo/QuickSelect.js
@@ -135,7 +135,7 @@ export default class QuickSelect extends Algorithm {
 			const list = listStr
 				.split(',')
 				.map(Number)
-				.filter(x => x)
+				.filter(x => !Number.isNaN(x))
 				.slice(0, 18);
 			const k = this.kField.value;
 			if (k > 0 && k <= list.length) {
@@ -171,7 +171,7 @@ export default class QuickSelect extends Algorithm {
 		this.arrayData = list
 			.split(',')
 			.map(Number)
-			.filter(x => x)
+			.filter(x => !Number.isNaN(x))
 			.slice(0, 18);
 		this.displayData = new Array(this.arrayData.length);
 

--- a/src/algo/SelectionSort.js
+++ b/src/algo/SelectionSort.js
@@ -133,7 +133,7 @@ export default class SelectionSort extends Algorithm {
 		this.arrayData = params
 			.split(',')
 			.map(Number)
-			.filter(x => x)
+			.filter(x => !Number.isNaN(x))
 			.slice(0, 18);
 		const length = this.arrayData.length;
 		this.displayData = new Array(length);
@@ -172,7 +172,13 @@ export default class SelectionSort extends Algorithm {
 			);
 		}
 
-		this.cmd(act.createHighlightCircle, this.iPointerID, '#FF0000', ARRAY_START_X, ARRAY_START_Y);
+		this.cmd(
+			act.createHighlightCircle,
+			this.iPointerID,
+			'#FF0000',
+			ARRAY_START_X,
+			ARRAY_START_Y
+		);
 		this.cmd(act.setHighlight, this.iPointerID, 1);
 		this.cmd(
 			act.createHighlightCircle,


### PR DESCRIPTION
Addresses #26 
`0` is a falsy value in JS, so `.filter(x => x)` was removing `0` from the input array.
`.filter(x => !Number.isNaN(x))` correctly removes `NaN` while preserving `0`.

Correctly preserves 0:
![image](https://user-images.githubusercontent.com/8410924/77451394-fc2f4880-6dca-11ea-8d3c-1d47e416ca3c.png)
![image](https://user-images.githubusercontent.com/8410924/77451326-e3269780-6dca-11ea-91da-a6fcebc38ee0.png)

Correctly removes invalid inputs:
![image](https://user-images.githubusercontent.com/8410924/77451446-10734580-6dcb-11ea-84a9-d069b74e008d.png)
![image](https://user-images.githubusercontent.com/8410924/77451483-1a954400-6dcb-11ea-8e96-2e74bb57d45c.png)