### PR TITLE
Array list resize

### DIFF
--- a/src/algo/ArrayList.js
+++ b/src/algo/ArrayList.js
@@ -199,6 +199,7 @@ export default class ArrayList extends Algorithm {
 		this.length = SIZE;
 		this.commands = [];
 
+		//Who needs this.arrayData? <- added comment so I can make a new commit for vercel
 
 		for (let i = 0; i < SIZE; i++) {
 			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;

--- a/src/algo/ArrayList.js
+++ b/src/algo/ArrayList.js
@@ -465,6 +465,7 @@ export default class ArrayList extends Algorithm {
 		}
 		this.cmd(act.step);
 
+		//Create new array to track moving objects. Similar function to presentID in add() and remove()
 		this.arrayMoveID = new Array(this.size);
 
 		//Move elements before index from old array

--- a/src/algo/ArrayList.js
+++ b/src/algo/ArrayList.js
@@ -199,8 +199,6 @@ export default class ArrayList extends Algorithm {
 		this.length = SIZE;
 		this.commands = [];
 
-		//Who needs this.arrayData? <- added comment so I can make a new commit for vercel
-
 		for (let i = 0; i < SIZE; i++) {
 			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
 			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;

--- a/src/algo/ArrayList.js
+++ b/src/algo/ArrayList.js
@@ -35,18 +35,22 @@ import { act } from '../anim/AnimationMain';
 
 const ARRAY_START_X = 100;
 const ARRAY_START_Y = 200;
+const RESIZE_ARRAY_START_X = 100;
+const RESIZE_ARRAY_START_Y = 330;
 const ARRAY_ELEM_WIDTH = 50;
 const ARRAY_ELEM_HEIGHT = 50;
 
-const ARRRAY_ELEMS_PER_LINE = 15;
+const ARRAY_ELEMS_PER_LINE = 15;
 const ARRAY_LINE_SPACING = 130;
 
 const PUSH_LABEL_X = 50;
 const PUSH_LABEL_Y = 30;
 const PUSH_ELEMENT_X = 120;
 const PUSH_ELEMENT_Y = 30;
+const PUSH_RESIZE_LABEL_X = 60;
+const PUSH_RESIZE_LABEL_Y = 60;
 
-const SIZE = 10;
+const SIZE = 7;
 
 export default class ArrayList extends Algorithm {
 	constructor(am, w, h) {
@@ -195,8 +199,8 @@ export default class ArrayList extends Algorithm {
 		this.commands = [];
 
 		for (let i = 0; i < SIZE; i++) {
-			const xpos = (i % ARRRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
-			const ypos = Math.floor(i / ARRRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
 			this.cmd(
 				act.createRectangle,
 				this.arrayID[i],
@@ -231,32 +235,43 @@ export default class ArrayList extends Algorithm {
 	addIndexCallback() {
 		if (
 			this.addValueField.value !== '' &&
-			this.addIndexField.value !== '' &&
-			this.size < SIZE
+			this.addIndexField.value !== ''
 		) {
 			const addVal = parseInt(this.addValueField.value);
 			const index = parseInt(this.addIndexField.value);
 			if (index >= 0 && index <= this.size) {
 				this.addValueField.value = '';
 				this.addIndexField.value = '';
-				this.implementAction(this.add.bind(this), addVal, index);
+				if (this.size === this.arrayData.length) {
+					this.implementAction(this.resize.bind(this), addVal, index);
+				} else {
+					this.implementAction(this.add.bind(this), addVal, index);
+				}
 			}
 		}
 	}
 
 	addFrontCallback() {
-		if (this.addValueField.value !== '' && this.size < SIZE) {
+		if (this.addValueField.value !== '') {
 			const addVal = parseInt(this.addValueField.value);
 			this.addValueField.value = '';
-			this.implementAction(this.add.bind(this), addVal, 0);
+			if (this.size === this.arrayData.length) {
+				this.implementAction(this.resize.bind(this), addVal, 0);
+			} else {
+				this.implementAction(this.add.bind(this), addVal, 0);
+			}
 		}
 	}
 
 	addBackCallback() {
-		if (this.addValueField.value !== '' && this.size < SIZE) {
+		if (this.addValueField.value !== '') {
 			const addVal = parseInt(this.addValueField.value);
 			this.addValueField.value = '';
-			this.implementAction(this.add.bind(this), addVal, this.size);
+			if (this.size === this.arrayData.length) {
+				this.implementAction(this.resize.bind(this), addVal, this.size);
+			} else {
+				this.implementAction(this.add.bind(this), addVal, this.size);
+			}
 		}
 	}
 
@@ -308,8 +323,8 @@ export default class ArrayList extends Algorithm {
 		this.cmd(act.step);
 
 		for (let i = this.size - 1; i >= index; i--) {
-			const xpos = (i % ARRRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
-			const ypos = Math.floor(i / ARRRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
 			const presentID = this.nextIndex + i;
 			this.cmd(act.createLabel, presentID, this.arrayData[i + 1], xpos, ypos);
 			this.cmd(act.setText, this.arrayID[i], '');
@@ -335,9 +350,9 @@ export default class ArrayList extends Algorithm {
 		);
 		this.cmd(act.step);
 
-		const xpos = (parseInt(index) % ARRRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+		const xpos = (parseInt(index) % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
 		const ypos =
-			Math.floor(parseInt(index) / ARRRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING +
+			Math.floor(parseInt(index) / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING +
 			ARRAY_START_Y;
 
 		this.cmd(act.move, this.highlight1ID, xpos, ypos);
@@ -362,8 +377,8 @@ export default class ArrayList extends Algorithm {
 		index = parseInt(index);
 		const labPopValID = this.nextIndex++;
 
-		const xpos = (index % ARRRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
-		const ypos = Math.floor(index / ARRRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+		const xpos = (index % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+		const ypos = Math.floor(index / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
 
 		this.cmd(act.createHighlightCircle, this.highlight1ID, '#0000FF', xpos, ypos);
 		this.cmd(act.createLabel, labPopValID, this.arrayData[index], xpos, ypos);
@@ -377,8 +392,8 @@ export default class ArrayList extends Algorithm {
 		this.cmd(act.step);
 
 		for (let i = index + 1; i < this.size; i++) {
-			const xpos = (i % ARRRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
-			const ypos = Math.floor(i / ARRRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
 			const presentID = this.nextIndex + i;
 			this.cmd(act.createLabel, presentID, this.arrayData[i], xpos, ypos);
 			this.cmd(act.setText, this.arrayID[i], '');
@@ -398,6 +413,154 @@ export default class ArrayList extends Algorithm {
 		}
 
 		this.size = this.size - 1;
+		return this.commands;
+	}
+
+	resize(elemToAdd, index) {
+		this.commands = [];
+
+		const labPushID = this.nextIndex++;
+		const labPushValID = this.nextIndex++;
+		const labPushResizeID = this.nextIndex++;
+
+		this.cmd(act.createLabel, labPushID, 'Adding Value: ', PUSH_LABEL_X, PUSH_LABEL_Y);
+		this.cmd(act.createLabel, labPushValID, elemToAdd, PUSH_ELEMENT_X, PUSH_ELEMENT_Y);
+		this.cmd(act.createLabel, labPushResizeID, '(Resize Required)', PUSH_RESIZE_LABEL_X, PUSH_RESIZE_LABEL_Y);
+		this.cmd(act.step);
+
+		this.arrayDataNew = new Array(this.size * 2);
+		this.arrayIDNew = new Array(this.size * 2);
+		this.arrayLabelIDNew = new Array(this.size * 2);
+
+		let arrayIndex = 0;
+
+		for (let i = 0; i < this.size * 2; i++) {
+			this.arrayIDNew[i] = this.nextIndex++;
+			this.arrayLabelIDNew[i] = this.nextIndex++;
+			if (i !== index && arrayIndex < this.size) {
+				this.arrayDataNew[i] = this.arrayData[arrayIndex++];
+			} else if (i === index) {
+				this.arrayDataNew[i] = elemToAdd;
+			}
+		}
+
+		this.highlight1ID = this.nextIndex++;
+		
+		//Create new array
+		for (let i = 0; i < this.size * 2; i++) {
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + RESIZE_ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING 
+			+ (RESIZE_ARRAY_START_Y);
+			this.cmd(
+				act.createRectangle,
+				this.arrayIDNew[i],
+				'',
+				ARRAY_ELEM_WIDTH,
+				ARRAY_ELEM_HEIGHT,
+				xpos,
+				ypos,
+			);
+			this.cmd(act.createLabel, this.arrayLabelIDNew[i], i, xpos, ypos + ARRAY_ELEM_HEIGHT);
+			this.cmd(act.setForegroundColor, this.arrayLabelIDNew[i], '#0000FF');
+		}
+		this.cmd(act.step);
+
+		this.arrayMoveID = new Array(this.size);
+
+		//Move elements before index from old array
+		for (let i = 0; i < index; i++) {
+			const xposinit = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+			const yposinit = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + RESIZE_ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING 
+			+ (RESIZE_ARRAY_START_Y);
+
+			this.arrayMoveID[i] = this.nextIndex++;
+
+			this.cmd(act.createLabel, this.arrayMoveID[i], this.arrayData[i], xposinit, yposinit);
+			this.cmd(act.move, this.arrayMoveID[i], xpos, ypos);
+		}
+		this.cmd(act.step);
+
+		//delete movement id objects and set text
+		for (let i = 0; i < index; i++) {
+			this.cmd(act.delete, this.arrayMoveID[i]);
+			this.cmd(act.setText, this.arrayIDNew[i], this.arrayDataNew[i]);
+		}
+
+		//Add elemToAdd at the index
+		this.cmd(
+			act.createHighlightCircle,
+			this.highlight1ID,
+			'#0000FF',
+			PUSH_ELEMENT_X,
+			PUSH_ELEMENT_Y,
+		);
+		this.cmd(act.step);
+
+		const xpos = (parseInt(index) % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + RESIZE_ARRAY_START_X;
+		const ypos =
+			Math.floor(parseInt(index) / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING +
+			RESIZE_ARRAY_START_Y;
+
+		this.cmd(act.move, this.highlight1ID, xpos, ypos);
+		this.cmd(act.move, labPushValID, xpos, ypos);
+		this.cmd(act.step);
+
+		this.cmd(act.setText, this.arrayIDNew[index], elemToAdd);
+		this.cmd(act.delete, labPushValID);
+		this.cmd(act.delete, this.highlight1ID);
+		this.cmd(act.step);
+
+		//Move elements after index from old array
+		for (let i = index; i < this.size; i++) {
+			const xposinit = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+			const yposinit = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + RESIZE_ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING 
+			+ (RESIZE_ARRAY_START_Y);
+
+			this.arrayMoveID[i] = this.nextIndex++;
+
+			this.cmd(act.createLabel, this.arrayMoveID[i], this.arrayData[i], xposinit, yposinit);
+			this.cmd(act.move, this.arrayMoveID[i], xpos + ARRAY_ELEM_WIDTH, ypos);
+		}
+		this.cmd(act.step);
+
+		//delete movement id objects
+		for (let i = index; i <= this.size; i++) {
+			if (i < this.size) {
+				this.cmd(act.delete, this.arrayMoveID[i]);
+			}
+			this.cmd(act.setText, this.arrayIDNew[i], this.arrayDataNew[i]);
+		}
+
+		this.cmd(act.delete, labPushID);
+		this.cmd(act.delete, labPushResizeID);
+		this.cmd(act.step);
+
+		for (let i = 0; i < this.size; i++) {
+			this.cmd(act.delete, this.arrayID[i]);
+			this.cmd(act.delete, this.arrayLabelID[i]);
+		}
+
+		for (let i = 0; i < this.size * 2; i++) {
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+
+			this.cmd(act.move, this.arrayIDNew[i], xpos, ypos);
+			this.cmd(act.move, this.arrayLabelIDNew[i], xpos, ypos + ARRAY_ELEM_HEIGHT);
+		}
+		this.cmd(act.step);
+
+		this.arrayData = this.arrayDataNew;
+		this.arrayID = this.arrayIDNew;
+		this.arrayLabelID = this.arrayLabelIDNew;
+
+		this.size = this.size + 1;
+
 		return this.commands;
 	}
 

--- a/src/algo/ArrayList.js
+++ b/src/algo/ArrayList.js
@@ -227,6 +227,8 @@ export default class ArrayList extends Algorithm {
 		this.nextIndex = 0;
 		this.size = 0;
 		this.length = SIZE;
+		this.arrayID = new Array(SIZE);
+		this.arrayLabelID = new Array(SIZE);
 		for (let i = 0; i < SIZE; i++) {
 			this.arrayID[i] = this.nextIndex++;
 			this.arrayLabelID[i] = this.nextIndex++;
@@ -319,9 +321,6 @@ export default class ArrayList extends Algorithm {
 	add(elemToAdd, index) {
 		this.commands = [];
 
-		console.log('nextIndex: ' + this.nextIndex);
-		console.log('highlight1ID: ' + this.highlight1ID);
-
 		const labPushID = this.nextIndex++;
 		const labPushValID = this.nextIndex++;
 
@@ -386,10 +385,6 @@ export default class ArrayList extends Algorithm {
 	remove(index) {
 		this.commands = [];
 
-		console.log('nextIndex: ' + this.nextIndex);
-		console.log('highlight1ID: ' + this.highlight1ID);
-		console.log('arrayID: ' + this.arrayID);
-
 		index = parseInt(index);
 		const labPopValID = this.nextIndex++;
 
@@ -437,9 +432,6 @@ export default class ArrayList extends Algorithm {
 
 	resize(elemToAdd, index) {
 		this.commands = [];
-
-		console.log('nextIndex: ' + this.nextIndex);
-		console.log('highlight1ID: ' + this.highlight1ID);
 
 		const labPushID = this.nextIndex++;
 		const labPushValID = this.nextIndex++;
@@ -577,7 +569,6 @@ export default class ArrayList extends Algorithm {
 			this.cmd(act.move, this.arrayLabelIDNew[i], xpos, ypos + ARRAY_ELEM_HEIGHT);
 		}
 
-		this.arrayData = this.arrayDataNew;
 		this.arrayID = this.arrayIDNew;
 		this.arrayLabelID = this.arrayLabelIDNew;
 
@@ -589,52 +580,6 @@ export default class ArrayList extends Algorithm {
 
 		return this.commands;
 	}
-
-	/*
-	* This data stack is necessary for tracking the 'arrayData' after each addition or deletion.
-	* This is necessary because after stepping the animation forward or backwards,
-	* the arrayData array is not updated.
-	* During resizes the data from arrayData is displayed, and without tracking the arrayData
-	* at each step the wrong data could be displayed
-	*/
-	// push_dataStack() {
-	// 	if (this.dataStack_top === this.dataStack.length) {
-	// 		this.resize_dataStack.bind(this).call();
-	// 	}
-	// 	this.dataStack[this.dataStack_top] = new Array(this.arrayData.length);
-	// 	for (let i = 0; i < this.arrayData.length; i++) {
-	// 		this.dataStack[this.dataStack_top][i] = this.arrayData[i];
-	// 	}
-
-	// 	this.dataStack_top++;
-	// 	return;
-	// }
-
-	// pop_dataStack() {
-	// 	this.dataStack_top = this.dataStack_top - 1;
-	// 	this.set_dataStack.bind(this).call();
-
-	// 	return;
-	// }
-
-	// set_dataStack() {
-	// 	this.arrayData = new Array(this.dataStack[this.dataStack_top - 1].length);
-	// 	for (let i = 0; i < this.arrayData.length; i++) {
-	// 		this.arrayData[i] = this.dataStack[this.dataStack_top - 1][i];
-	// 	}
-
-	// 	return;
-	// }
-
-	// resize_dataStack() {
-	// 	this.newDataStack = new Array(this.dataStack.length * 2);
-	// 	for (let i = 0; i < this.dataStack.length; i++) {
-	// 		this.newDataStack[i] = this.dataStack[i];
-	// 	}
-
-	// 	this.dataStack = this.newDataStack;
-	// 	return;
-	// }
 
 	clearAll() {
 		this.commands = [];

--- a/src/algo/ArrayList.js
+++ b/src/algo/ArrayList.js
@@ -188,7 +188,6 @@ export default class ArrayList extends Algorithm {
 	}
 
 	setup() {
-		// this.arrayData = new Array(SIZE);
 		this.arrayID = new Array(SIZE);
 		this.arrayLabelID = new Array(SIZE);
 		for (let i = 0; i < SIZE; i++) {
@@ -197,15 +196,9 @@ export default class ArrayList extends Algorithm {
 		}
 
 		this.size = 0;
-		//this.length is a necessary replacement for this.arrayData.length for resize calculations
-		//because the 'skip back' button in the gui does not reset the arrays themselves, but rather
-		//keeps the same arrays but resets the old values at the indices they would've been in the new array
 		this.length = SIZE;
 		this.commands = [];
 
-		// this.dataStack_top = 0;
-		// this.dataStack = new Array(MAX_SIZE);
-		// this.dataStack[this.dataStack_top++] = new Array(SIZE);
 
 		for (let i = 0; i < SIZE; i++) {
 			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
@@ -239,7 +232,6 @@ export default class ArrayList extends Algorithm {
 			this.arrayLabelID[i] = this.nextIndex++;
 		}
 		this.highlight1ID = this.nextIndex++;
-		// this.pop_dataStack.bind(this).call();
 	}
 
 	addIndexCallback() {
@@ -259,7 +251,6 @@ export default class ArrayList extends Algorithm {
 					this.implementAction(this.add.bind(this), addVal, index);
 				}
 			}
-			// this.push_dataStack.bind(this).call();
 		}
 	}
 
@@ -275,7 +266,6 @@ export default class ArrayList extends Algorithm {
 			} else {
 				this.implementAction(this.add.bind(this), addVal, 0);
 			}
-			// this.push_dataStack.bind(this).call();
 		}
 	}
 
@@ -291,7 +281,6 @@ export default class ArrayList extends Algorithm {
 			} else {
 				this.implementAction(this.add.bind(this), addVal, this.size);
 			}
-			// this.push_dataStack.bind(this).call();
 		}
 	}
 
@@ -302,21 +291,18 @@ export default class ArrayList extends Algorithm {
 				this.removeField.value = '';
 				this.implementAction(this.remove.bind(this), index);
 			}
-			// this.push_dataStack.bind(this).call();
 		}
 	}
 
 	removeFrontCallback() {
 		if (this.size > 0) {
 			this.implementAction(this.remove.bind(this), 0);
-			// this.push_dataStack.bind(this).call();
 		}
 	}
 
 	removeBackCallback() {
 		if (this.size > 0) {
 			this.implementAction(this.remove.bind(this), this.size - 1);
-			// this.push_dataStack.bind(this).call();
 		}
 	}
 
@@ -333,15 +319,11 @@ export default class ArrayList extends Algorithm {
 	add(elemToAdd, index) {
 		this.commands = [];
 
-		// this.set_dataStack.bind(this).call();
+		console.log('nextIndex: ' + this.nextIndex);
+		console.log('highlight1ID: ' + this.highlight1ID);
 
 		const labPushID = this.nextIndex++;
 		const labPushValID = this.nextIndex++;
-
-		// for (let i = this.size - 1; i >= index; i--) {
-		// 	this.arrayData[i + 1] = this.arrayData[i];
-		// }
-		// this.arrayData[index] = elemToAdd;
 
 		this.cmd(act.createLabel, labPushID, 'Adding Value: ', PUSH_LABEL_X, PUSH_LABEL_Y);
 		this.cmd(act.createLabel, labPushValID, elemToAdd, PUSH_ELEMENT_X, PUSH_ELEMENT_Y);
@@ -353,14 +335,14 @@ export default class ArrayList extends Algorithm {
 			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
 			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
 			this.arrayMoveID[i] = this.nextIndex++;
-			this.cmd(act.createLabel, this.arrayMoveID[i], this.animationManager.objectManager.getText(this.arrayID[i + 1]), xpos, ypos);
+			this.cmd(act.createLabel, this.arrayMoveID[i], this.animationManager.objectManager.getText(this.arrayID[i]), xpos, ypos);
 			this.cmd(act.setText, this.arrayID[i], '');
 			this.cmd(act.move, this.arrayMoveID[i], xpos + ARRAY_ELEM_WIDTH, ypos);
 		}
 		this.cmd(act.step);
 
 		for (let i = this.size - 1; i >= index; i--) {
-			this.cmd(act.setText, this.arrayID[i + 1], this.animationManager.objectManager.getText(this.arrayID[i + 1]));
+			this.cmd(act.setText, this.arrayID[i + 1], this.animationManager.objectManager.getText(this.arrayID[i]));
 			this.cmd(act.delete, this.arrayMoveID[i]);
 		}
 		this.cmd(act.step);
@@ -391,6 +373,12 @@ export default class ArrayList extends Algorithm {
 		this.cmd(act.delete, labPushID);
 		this.cmd(act.step);
 
+		if (index != null) {
+			this.nextIndex = this.nextIndex - (this.size - index) - 2;
+		} else {
+			this.nextIndex = this.nextIndex - 2;
+		}
+
 		this.size = this.size + 1;
 		return this.commands;
 	}
@@ -398,7 +386,9 @@ export default class ArrayList extends Algorithm {
 	remove(index) {
 		this.commands = [];
 
-		// this.set_dataStack.bind(this).call();
+		console.log('nextIndex: ' + this.nextIndex);
+		console.log('highlight1ID: ' + this.highlight1ID);
+		console.log('arrayID: ' + this.arrayID);
 
 		index = parseInt(index);
 		const labPopValID = this.nextIndex++;
@@ -435,9 +425,11 @@ export default class ArrayList extends Algorithm {
 		}
 		this.cmd(act.step);
 
-		// for (let i = index; i < this.size; i++) {
-		// 	this.arrayData[i] = this.arrayData[i + 1];
-		// }
+		if (index != null) {
+			this.nextIndex = this.nextIndex - (this.size - index);
+		} else {
+			this.nextIndex = this.nextIndex - 2;
+		}
 
 		this.size = this.size - 1;
 		return this.commands;
@@ -445,6 +437,9 @@ export default class ArrayList extends Algorithm {
 
 	resize(elemToAdd, index) {
 		this.commands = [];
+
+		console.log('nextIndex: ' + this.nextIndex);
+		console.log('highlight1ID: ' + this.highlight1ID);
 
 		const labPushID = this.nextIndex++;
 		const labPushValID = this.nextIndex++;
@@ -455,22 +450,15 @@ export default class ArrayList extends Algorithm {
 		this.cmd(act.createLabel, labPushResizeID, '(Resize Required)', PUSH_RESIZE_LABEL_X, PUSH_RESIZE_LABEL_Y);
 		this.cmd(act.step);
 
-		// this.arrayDataNew = new Array(this.size * 2);
 		this.arrayIDNew = new Array(this.size * 2);
 		this.arrayLabelIDNew = new Array(this.size * 2);
 
 		this.length = this.length * 2;
 
-		// let arrayIndex = 0;
 
 		for (let i = 0; i < this.size * 2; i++) {
 			this.arrayIDNew[i] = this.nextIndex++;
 			this.arrayLabelIDNew[i] = this.nextIndex++;
-			// if (i !== index && arrayIndex < this.arrayData.length) {
-			// 	this.arrayDataNew[i] = this.arrayData[arrayIndex++];
-			// } else if (i === index) {
-			// 	this.arrayDataNew[i] = elemToAdd;
-			// }
 		}
 
 		this.highlight1ID = this.nextIndex++;
@@ -592,6 +580,10 @@ export default class ArrayList extends Algorithm {
 		this.arrayData = this.arrayDataNew;
 		this.arrayID = this.arrayIDNew;
 		this.arrayLabelID = this.arrayLabelIDNew;
+
+		if (index != null) {
+			this.nextIndex = this.nextIndex - this.size;
+		}
 
 		this.size = this.size + 1;
 


### PR DESCRIPTION
Closes #62 

Added ArrayList Resizing, activated automatically when an index would be added out of bounds using add front, add back, or add at index. Also changed the initial array size to 7 so that after 1 resize the array doesn't wrap around to the next line immediately.

Resizing when adding to front:
![AddFrontResize](https://user-images.githubusercontent.com/64664063/100184560-c4bff100-2eaf-11eb-954b-5955e30619fe.gif)

Resizing when adding to back:
![AddBackResizeInit](https://user-images.githubusercontent.com/64664063/100184603-e0c39280-2eaf-11eb-9015-7dea8854544c.gif)

Resizing when adding at an index:
![ResizeIndex](https://user-images.githubusercontent.com/64664063/100184789-46178380-2eb0-11eb-9024-059420949c16.gif)

Resizing after the array has already been resized:
![AddBackResize](https://user-images.githubusercontent.com/64664063/100184736-2a13e200-2eb0-11eb-8e6e-da0b069584f6.gif)

Also, adding after a resize works as normal as well!
![AddIndex](https://user-images.githubusercontent.com/64664063/100184774-3dbf4880-2eb0-11eb-8e43-75ce9feaa184.gif)

I can change the initial size back, I just personally thought it looked nicer. Also, currently the array can be resized infinitely which could lead to array elements that leave the screen, so I can add a cap to the amount of resizes possible.