### PR TITLE
Stack array resize

### DIFF
--- a/src/algo/ArrayList.js
+++ b/src/algo/ArrayList.js
@@ -465,6 +465,7 @@ export default class ArrayList extends Algorithm {
 		}
 		this.cmd(act.step);
 
+		//Create new array to track moving objects. Similar function to presentID in add() and remove()
 		this.arrayMoveID = new Array(this.size);
 
 		//Move elements before index from old array

--- a/src/algo/ArrayList.js
+++ b/src/algo/ArrayList.js
@@ -35,18 +35,22 @@ import { act } from '../anim/AnimationMain';
 
 const ARRAY_START_X = 100;
 const ARRAY_START_Y = 200;
+const RESIZE_ARRAY_START_X = 100;
+const RESIZE_ARRAY_START_Y = 330;
 const ARRAY_ELEM_WIDTH = 50;
 const ARRAY_ELEM_HEIGHT = 50;
 
-const ARRRAY_ELEMS_PER_LINE = 15;
+const ARRAY_ELEMS_PER_LINE = 15;
 const ARRAY_LINE_SPACING = 130;
 
 const PUSH_LABEL_X = 50;
 const PUSH_LABEL_Y = 30;
 const PUSH_ELEMENT_X = 120;
 const PUSH_ELEMENT_Y = 30;
+const PUSH_RESIZE_LABEL_X = 60;
+const PUSH_RESIZE_LABEL_Y = 60;
 
-const SIZE = 10;
+const SIZE = 7;
 
 export default class ArrayList extends Algorithm {
 	constructor(am, w, h) {
@@ -195,8 +199,8 @@ export default class ArrayList extends Algorithm {
 		this.commands = [];
 
 		for (let i = 0; i < SIZE; i++) {
-			const xpos = (i % ARRRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
-			const ypos = Math.floor(i / ARRRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
 			this.cmd(
 				act.createRectangle,
 				this.arrayID[i],
@@ -231,32 +235,43 @@ export default class ArrayList extends Algorithm {
 	addIndexCallback() {
 		if (
 			this.addValueField.value !== '' &&
-			this.addIndexField.value !== '' &&
-			this.size < SIZE
+			this.addIndexField.value !== ''
 		) {
 			const addVal = parseInt(this.addValueField.value);
 			const index = parseInt(this.addIndexField.value);
 			if (index >= 0 && index <= this.size) {
 				this.addValueField.value = '';
 				this.addIndexField.value = '';
-				this.implementAction(this.add.bind(this), addVal, index);
+				if (this.size === this.arrayData.length) {
+					this.implementAction(this.resize.bind(this), addVal, index);
+				} else {
+					this.implementAction(this.add.bind(this), addVal, index);
+				}
 			}
 		}
 	}
 
 	addFrontCallback() {
-		if (this.addValueField.value !== '' && this.size < SIZE) {
+		if (this.addValueField.value !== '') {
 			const addVal = parseInt(this.addValueField.value);
 			this.addValueField.value = '';
-			this.implementAction(this.add.bind(this), addVal, 0);
+			if (this.size === this.arrayData.length) {
+				this.implementAction(this.resize.bind(this), addVal, 0);
+			} else {
+				this.implementAction(this.add.bind(this), addVal, 0);
+			}
 		}
 	}
 
 	addBackCallback() {
-		if (this.addValueField.value !== '' && this.size < SIZE) {
+		if (this.addValueField.value !== '') {
 			const addVal = parseInt(this.addValueField.value);
 			this.addValueField.value = '';
-			this.implementAction(this.add.bind(this), addVal, this.size);
+			if (this.size === this.arrayData.length) {
+				this.implementAction(this.resize.bind(this), addVal, this.size);
+			} else {
+				this.implementAction(this.add.bind(this), addVal, this.size);
+			}
 		}
 	}
 
@@ -308,8 +323,8 @@ export default class ArrayList extends Algorithm {
 		this.cmd(act.step);
 
 		for (let i = this.size - 1; i >= index; i--) {
-			const xpos = (i % ARRRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
-			const ypos = Math.floor(i / ARRRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
 			const presentID = this.nextIndex + i;
 			this.cmd(act.createLabel, presentID, this.arrayData[i + 1], xpos, ypos);
 			this.cmd(act.setText, this.arrayID[i], '');
@@ -335,9 +350,9 @@ export default class ArrayList extends Algorithm {
 		);
 		this.cmd(act.step);
 
-		const xpos = (parseInt(index) % ARRRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+		const xpos = (parseInt(index) % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
 		const ypos =
-			Math.floor(parseInt(index) / ARRRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING +
+			Math.floor(parseInt(index) / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING +
 			ARRAY_START_Y;
 
 		this.cmd(act.move, this.highlight1ID, xpos, ypos);
@@ -362,8 +377,8 @@ export default class ArrayList extends Algorithm {
 		index = parseInt(index);
 		const labPopValID = this.nextIndex++;
 
-		const xpos = (index % ARRRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
-		const ypos = Math.floor(index / ARRRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+		const xpos = (index % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+		const ypos = Math.floor(index / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
 
 		this.cmd(act.createHighlightCircle, this.highlight1ID, '#0000FF', xpos, ypos);
 		this.cmd(act.createLabel, labPopValID, this.arrayData[index], xpos, ypos);
@@ -377,8 +392,8 @@ export default class ArrayList extends Algorithm {
 		this.cmd(act.step);
 
 		for (let i = index + 1; i < this.size; i++) {
-			const xpos = (i % ARRRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
-			const ypos = Math.floor(i / ARRRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
 			const presentID = this.nextIndex + i;
 			this.cmd(act.createLabel, presentID, this.arrayData[i], xpos, ypos);
 			this.cmd(act.setText, this.arrayID[i], '');
@@ -398,6 +413,154 @@ export default class ArrayList extends Algorithm {
 		}
 
 		this.size = this.size - 1;
+		return this.commands;
+	}
+
+	resize(elemToAdd, index) {
+		this.commands = [];
+
+		const labPushID = this.nextIndex++;
+		const labPushValID = this.nextIndex++;
+		const labPushResizeID = this.nextIndex++;
+
+		this.cmd(act.createLabel, labPushID, 'Adding Value: ', PUSH_LABEL_X, PUSH_LABEL_Y);
+		this.cmd(act.createLabel, labPushValID, elemToAdd, PUSH_ELEMENT_X, PUSH_ELEMENT_Y);
+		this.cmd(act.createLabel, labPushResizeID, '(Resize Required)', PUSH_RESIZE_LABEL_X, PUSH_RESIZE_LABEL_Y);
+		this.cmd(act.step);
+
+		this.arrayDataNew = new Array(this.size * 2);
+		this.arrayIDNew = new Array(this.size * 2);
+		this.arrayLabelIDNew = new Array(this.size * 2);
+
+		let arrayIndex = 0;
+
+		for (let i = 0; i < this.size * 2; i++) {
+			this.arrayIDNew[i] = this.nextIndex++;
+			this.arrayLabelIDNew[i] = this.nextIndex++;
+			if (i !== index && arrayIndex < this.size) {
+				this.arrayDataNew[i] = this.arrayData[arrayIndex++];
+			} else if (i === index) {
+				this.arrayDataNew[i] = elemToAdd;
+			}
+		}
+
+		this.highlight1ID = this.nextIndex++;
+		
+		//Create new array
+		for (let i = 0; i < this.size * 2; i++) {
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + RESIZE_ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING 
+			+ (RESIZE_ARRAY_START_Y);
+			this.cmd(
+				act.createRectangle,
+				this.arrayIDNew[i],
+				'',
+				ARRAY_ELEM_WIDTH,
+				ARRAY_ELEM_HEIGHT,
+				xpos,
+				ypos,
+			);
+			this.cmd(act.createLabel, this.arrayLabelIDNew[i], i, xpos, ypos + ARRAY_ELEM_HEIGHT);
+			this.cmd(act.setForegroundColor, this.arrayLabelIDNew[i], '#0000FF');
+		}
+		this.cmd(act.step);
+
+		this.arrayMoveID = new Array(this.size);
+
+		//Move elements before index from old array
+		for (let i = 0; i < index; i++) {
+			const xposinit = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+			const yposinit = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + RESIZE_ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING 
+			+ (RESIZE_ARRAY_START_Y);
+
+			this.arrayMoveID[i] = this.nextIndex++;
+
+			this.cmd(act.createLabel, this.arrayMoveID[i], this.arrayData[i], xposinit, yposinit);
+			this.cmd(act.move, this.arrayMoveID[i], xpos, ypos);
+		}
+		this.cmd(act.step);
+
+		//delete movement id objects and set text
+		for (let i = 0; i < index; i++) {
+			this.cmd(act.delete, this.arrayMoveID[i]);
+			this.cmd(act.setText, this.arrayIDNew[i], this.arrayDataNew[i]);
+		}
+
+		//Add elemToAdd at the index
+		this.cmd(
+			act.createHighlightCircle,
+			this.highlight1ID,
+			'#0000FF',
+			PUSH_ELEMENT_X,
+			PUSH_ELEMENT_Y,
+		);
+		this.cmd(act.step);
+
+		const xpos = (parseInt(index) % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + RESIZE_ARRAY_START_X;
+		const ypos =
+			Math.floor(parseInt(index) / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING +
+			RESIZE_ARRAY_START_Y;
+
+		this.cmd(act.move, this.highlight1ID, xpos, ypos);
+		this.cmd(act.move, labPushValID, xpos, ypos);
+		this.cmd(act.step);
+
+		this.cmd(act.setText, this.arrayIDNew[index], elemToAdd);
+		this.cmd(act.delete, labPushValID);
+		this.cmd(act.delete, this.highlight1ID);
+		this.cmd(act.step);
+
+		//Move elements after index from old array
+		for (let i = index; i < this.size; i++) {
+			const xposinit = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+			const yposinit = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + RESIZE_ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING 
+			+ (RESIZE_ARRAY_START_Y);
+
+			this.arrayMoveID[i] = this.nextIndex++;
+
+			this.cmd(act.createLabel, this.arrayMoveID[i], this.arrayData[i], xposinit, yposinit);
+			this.cmd(act.move, this.arrayMoveID[i], xpos + ARRAY_ELEM_WIDTH, ypos);
+		}
+		this.cmd(act.step);
+
+		//delete movement id objects
+		for (let i = index; i <= this.size; i++) {
+			if (i < this.size) {
+				this.cmd(act.delete, this.arrayMoveID[i]);
+			}
+			this.cmd(act.setText, this.arrayIDNew[i], this.arrayDataNew[i]);
+		}
+
+		this.cmd(act.delete, labPushID);
+		this.cmd(act.delete, labPushResizeID);
+		this.cmd(act.step);
+
+		for (let i = 0; i < this.size; i++) {
+			this.cmd(act.delete, this.arrayID[i]);
+			this.cmd(act.delete, this.arrayLabelID[i]);
+		}
+
+		for (let i = 0; i < this.size * 2; i++) {
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+
+			this.cmd(act.move, this.arrayIDNew[i], xpos, ypos);
+			this.cmd(act.move, this.arrayLabelIDNew[i], xpos, ypos + ARRAY_ELEM_HEIGHT);
+		}
+		this.cmd(act.step);
+
+		this.arrayData = this.arrayDataNew;
+		this.arrayID = this.arrayIDNew;
+		this.arrayLabelID = this.arrayLabelIDNew;
+
+		this.size = this.size + 1;
+
 		return this.commands;
 	}
 

--- a/src/algo/StackArray.js
+++ b/src/algo/StackArray.js
@@ -34,7 +34,7 @@ const RESIZE_ARRAY_START_Y = 330;
 const ARRAY_ELEM_WIDTH = 50;
 const ARRAY_ELEM_HEIGHT = 50;
 
-const ARRAY_ELEMS_PER_LINE = 15;
+const ARRAY_ELEMS_PER_LINE = 14;
 const ARRAY_LINE_SPACING = 130;
 
 const TOP_POS_X = 180;
@@ -160,13 +160,13 @@ export default class StackArray extends Algorithm {
 	}
 
 	pushCallback() {
-		if (this.top < MAX_SIZE 
-			&& this.top < this.arrayData.length
+		if (this.top < this.arrayData.length
 			&& this.pushField.value !== '') {
 			const pushVal = this.pushField.value;
 			this.pushField.value = '';
 			this.implementAction(this.push.bind(this), pushVal);
-		} else if (this.top === this.arrayData.length) {
+		} else if (this.top === this.arrayData.length
+			&& this.top * 2 < MAX_SIZE) {
 			const pushVal = this.pushField.value;
 			this.pushField.value = '';
 			this.implementAction(this.resize.bind(this), pushVal);


### PR DESCRIPTION
Closes #61 

Added the ability to resize Stack Arrays when they're full!
![resizeStackArray](https://user-images.githubusercontent.com/64664063/101995253-aa02c000-3c96-11eb-81ee-a2351e7b0211.gif)

Overall very similar to ArrayList resizing but without indices. 

Some new things I changed specifically for StackArray resizing:
1. Like ArrayList resizing, I changed the initial array size to 7, and I can certainly change it back
2. To keep a consistent length between resized lines (specifically after 2 resizes, when the array length is 28), I changed the maximum elements per line from 15 to 14. **However**, an alternative for both of these could be to potentially change the max elements per line to something much larger (I don't know how well this would work on some devices though)
Example:
![resizeStackArray2](https://user-images.githubusercontent.com/64664063/101995444-d703a280-3c97-11eb-8459-86038d077fcc.gif)

3. Unlike ArrayList resizing, I added a max size to the array stack so that you can't infinitely resize past what the screen can show. This max size is currently 30, meaning you can only resize twice.