### PR TITLE
StackArray Resize

### DIFF
--- a/src/algo/StackArray.js
+++ b/src/algo/StackArray.js
@@ -67,8 +67,7 @@ export default class StackArray extends Algorithm {
 		this.pushField.onkeydown = this.returnSubmit(
 			this.pushField,
 			this.pushCallback.bind(this),
-			4,
-			true
+			4
 		);
 
 		this.pushButton = addControlToAlgorithmBar('Button', 'Push');

--- a/src/algo/StackArray.js
+++ b/src/algo/StackArray.js
@@ -31,8 +31,10 @@ const ARRAY_START_X = 100;
 const ARRAY_START_Y = 200;
 const ARRAY_ELEM_WIDTH = 50;
 const ARRAY_ELEM_HEIGHT = 50;
+const RESIZE_ARRAY_START_X = 100;
+const RESIZE_ARRAY_START_Y = 300;
 
-const ARRRAY_ELEMS_PER_LINE = 15;
+const ARRAY_ELEMS_PER_LINE = 14;
 const ARRAY_LINE_SPACING = 130;
 
 const TOP_POS_X = 180;
@@ -44,8 +46,11 @@ const PUSH_LABEL_X = 50;
 const PUSH_LABEL_Y = 30;
 const PUSH_ELEMENT_X = 120;
 const PUSH_ELEMENT_Y = 30;
+const PUSH_RESIZE_LABEL_X = 60;
+const PUSH_RESIZE_LABEL_Y = 60;
 
-const SIZE = 30;
+const SIZE = 7;
+const MAX_SIZE = 30;
 
 export default class StackArray extends Algorithm {
 	constructor(am, w, h) {
@@ -54,7 +59,6 @@ export default class StackArray extends Algorithm {
 		this.nextIndex = 0;
 		this.commands = [];
 		this.setup();
-		this.initialIndex = this.nextIndex;
 	}
 
 	addControls() {
@@ -64,6 +68,7 @@ export default class StackArray extends Algorithm {
 			this.pushField,
 			this.pushCallback.bind(this),
 			4,
+			true
 		);
 
 		this.pushButton = addControlToAlgorithmBar('Button', 'Push');
@@ -101,21 +106,23 @@ export default class StackArray extends Algorithm {
 
 		this.arrayID = new Array(SIZE);
 		this.arrayLabelID = new Array(SIZE);
+		this.arrayData = new Array(SIZE);
+
 		for (let i = 0; i < SIZE; i++) {
 			this.arrayID[i] = this.nextIndex++;
 			this.arrayLabelID[i] = this.nextIndex++;
 		}
+
 		this.topID = this.nextIndex++;
 		this.topLabelID = this.nextIndex++;
 
-		this.arrayData = new Array(SIZE);
 		this.top = 0;
 		this.leftoverLabelID = this.nextIndex++;
 		this.commands = [];
 
 		for (let i = 0; i < SIZE; i++) {
-			const xpos = (i % ARRRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
-			const ypos = Math.floor(i / ARRRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
 			this.cmd(
 				act.createRectangle,
 				this.arrayID[i],
@@ -151,14 +158,35 @@ export default class StackArray extends Algorithm {
 
 	reset() {
 		this.top = 0;
-		this.nextIndex = this.initialIndex;
+		this.nextIndex = 0;
+		this.length = SIZE;
+
+		this.arrayID = new Array(SIZE);
+		this.arrayLabelID = new Array(SIZE);
+		this.arrayData = new Array(SIZE);
+
+		for(let i = 0; i < SIZE; i++) {
+			this.arrayID[i] = this.nextIndex++;
+			this.arrayLabelID[i] = this.nextIndex++;
+		}
+
+		this.nextIndex = this.nextIndex + 3;
+		//^ To keep nextIndex in the same place relative to setup()
+		this.highlight1ID = this.nextIndex++;
+		this.highlight2ID = this.nextIndex++;
 	}
 
 	pushCallback() {
-		if (this.top < SIZE && this.pushField.value !== '') {
+		if (this.top < this.arrayData.length
+			&& this.pushField.value !== '') {
 			const pushVal = this.pushField.value;
 			this.pushField.value = '';
 			this.implementAction(this.push.bind(this), pushVal);
+		} else if (this.top === this.arrayData.length
+			&& this.top * 2 < MAX_SIZE) {
+			const pushVal = this.pushField.value;
+			this.pushField.value = '';
+			this.implementAction(this.resize.bind(this), pushVal);
 		}
 	}
 
@@ -181,9 +209,10 @@ export default class StackArray extends Algorithm {
 	push(elemToPush) {
 		this.commands = [];
 
+		this.arrayData[this.top] = elemToPush;
+
 		const labPushID = this.nextIndex++;
 		const labPushValID = this.nextIndex++;
-		this.arrayData[this.top] = elemToPush;
 
 		this.cmd(act.setText, this.leftoverLabelID, '');
 
@@ -191,17 +220,13 @@ export default class StackArray extends Algorithm {
 		this.cmd(act.createLabel, labPushValID, elemToPush, PUSH_ELEMENT_X, PUSH_ELEMENT_Y);
 
 		this.cmd(act.step);
-		this.cmd(act.step);
-		this.cmd(act.step);
 		this.cmd(act.createHighlightCircle, this.highlight1ID, '#0000FF', TOP_POS_X, TOP_POS_Y);
 		this.cmd(act.step);
 
-		const xpos = (this.top % ARRRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+		const xpos = (this.top % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
 		const ypos =
-			Math.floor(this.top / ARRRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+			Math.floor(this.top / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
 
-		this.cmd(act.move, this.highlight1ID, xpos, ypos + ARRAY_ELEM_HEIGHT);
-		this.cmd(act.move, this.highlight1ID, xpos, ypos + ARRAY_ELEM_HEIGHT);
 		this.cmd(act.move, this.highlight1ID, xpos, ypos + ARRAY_ELEM_HEIGHT);
 		this.cmd(act.step);
 
@@ -221,6 +246,10 @@ export default class StackArray extends Algorithm {
 		this.cmd(act.step);
 		this.cmd(act.setHighlight, this.topID, 0);
 
+		if (elemToPush != null) {
+			this.nextIndex = this.nextIndex - 2;
+		}
+
 		return this.commands;
 	}
 
@@ -237,6 +266,10 @@ export default class StackArray extends Algorithm {
 		this.cmd(act.setHighlight, this.topID, 1);
 		this.cmd(act.step);
 		this.top = this.top - 1;
+
+		const popVal = this.arrayData[this.top];
+		this.arrayData[this.top] = '';
+
 		this.cmd(act.setText, this.topID, this.top);
 		this.cmd(act.step);
 		this.cmd(act.setHighlight, this.topID, 0);
@@ -244,23 +277,158 @@ export default class StackArray extends Algorithm {
 		this.cmd(act.createHighlightCircle, this.highlight1ID, '#0000FF', TOP_POS_X, TOP_POS_Y);
 		this.cmd(act.step);
 
-		const xpos = (this.top % ARRRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+		const xpos = (this.top % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
 		const ypos =
-			Math.floor(this.top / ARRRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+			Math.floor(this.top / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
 
-		this.cmd(act.move, this.highlight1ID, xpos, ypos + ARRAY_ELEM_HEIGHT);
-		this.cmd(act.move, this.highlight1ID, xpos, ypos + ARRAY_ELEM_HEIGHT);
 		this.cmd(act.move, this.highlight1ID, xpos, ypos + ARRAY_ELEM_HEIGHT);
 		this.cmd(act.step);
 
-		this.cmd(act.createLabel, labPopValID, this.arrayData[this.top], xpos, ypos);
+		this.cmd(act.createLabel, labPopValID, popVal, xpos, ypos);
 		this.cmd(act.setText, this.arrayID[this.top], '');
 		this.cmd(act.move, labPopValID, PUSH_ELEMENT_X, PUSH_ELEMENT_Y);
 		this.cmd(act.step);
-		this.cmd(act.delete, labPopValID);
 		this.cmd(act.delete, labPopID);
 		this.cmd(act.delete, this.highlight1ID);
-		this.cmd(act.setText, this.leftoverLabelID, 'Popped Value: ' + this.arrayData[this.top]);
+		this.cmd(act.setText, this.leftoverLabelID, 'Popped Value: ' + popVal);
+		this.cmd(act.delete, labPopValID);
+
+		this.nextIndex = this.nextIndex - 2;
+
+		return this.commands;
+	}
+
+	resize(elemToPush) {
+		this.commands = [];
+
+		const labPushID = this.nextIndex++;
+		const labPushValID = this.nextIndex++;
+		const labPushResizeID = this.nextIndex++;
+
+		this.cmd(act.createLabel, labPushID, 'Pushing Value: ', PUSH_LABEL_X, PUSH_LABEL_Y);
+		this.cmd(act.createLabel, labPushValID, elemToPush, PUSH_ELEMENT_X, PUSH_ELEMENT_Y);
+		this.cmd(act.createLabel, labPushResizeID, '(Resize Required)', PUSH_RESIZE_LABEL_X, PUSH_RESIZE_LABEL_Y);
+		this.cmd(act.step);
+
+		this.arrayIDNew = new Array(this.top * 2);
+		this.arrayLabelIDNew = new Array(this.top * 2);
+		this.arrayDataNew = new Array(this.top * 2);
+
+		for (let i = 0; i < this.top * 2; i++) {
+			this.arrayIDNew[i] = this.nextIndex++;
+			this.arrayLabelIDNew[i] = this.nextIndex++;
+			if (i < this.top) {
+				this.arrayDataNew[i] = this.arrayData[i];
+			}
+		}
+		this.arrayDataNew[this.top] = elemToPush;
+
+		this.highlight1ID = this.nextIndex++;
+
+		//Create new array
+		for (let i = 0; i < this.top * 2; i++) {
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + RESIZE_ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING 
+			+ (RESIZE_ARRAY_START_Y);
+			this.cmd(
+				act.createRectangle,
+				this.arrayIDNew[i],
+				'',
+				ARRAY_ELEM_WIDTH,
+				ARRAY_ELEM_HEIGHT,
+				xpos,
+				ypos,
+			);
+			this.cmd(act.createLabel, this.arrayLabelIDNew[i], i, xpos, ypos + ARRAY_ELEM_HEIGHT);
+			this.cmd(act.setForegroundColor, this.arrayLabelIDNew[i], '#0000FF');
+		}
+		this.cmd(act.step);
+
+		this.arrayMoveID = new Array(this.top);
+
+		//Move old array elements to the new array
+		for (let i = 0; i < this.top; i++) {
+			const xposinit = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+			const yposinit = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + RESIZE_ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING 
+			+ (RESIZE_ARRAY_START_Y);
+
+			this.arrayMoveID[i] = this.nextIndex++;
+
+			// const display = this.animationManager.objectManager.getText(this.arrayID[i]);
+			const display = this.arrayData[i];
+
+			this.cmd(act.createLabel, this.arrayMoveID[i], display, xposinit, yposinit);
+			this.cmd(act.move, this.arrayMoveID[i], xpos, ypos);
+		}
+		this.cmd(act.step);
+
+		//delete movement id objects and set text
+		for (let i = 0; i < this.top; i++) {
+			// const display = this.animationManager.objectManager.getText(this.arrayID[i]);
+			const display = this.arrayData[i];
+
+			this.cmd(act.setText, this.arrayIDNew[i], display);
+			this.cmd(act.delete, this.arrayMoveID[i]);
+		}
+		this.cmd(act.step);
+
+		//Add elemToPush at the index
+		this.cmd(
+			act.createHighlightCircle,
+			this.highlight1ID,
+			'#0000FF',
+			PUSH_ELEMENT_X,
+			PUSH_ELEMENT_Y,
+		);
+		this.cmd(act.step);
+
+		const xpos = (parseInt(this.top) % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + RESIZE_ARRAY_START_X;
+		const ypos =
+			Math.floor(parseInt(this.top) / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING +
+			RESIZE_ARRAY_START_Y;
+
+		this.cmd(act.move, this.highlight1ID, xpos, ypos);
+		this.cmd(act.move, labPushValID, xpos, ypos);
+		this.cmd(act.step);
+
+		this.cmd(act.setText, this.arrayIDNew[this.top], elemToPush);
+		this.cmd(act.delete, labPushValID);
+		this.cmd(act.delete, this.highlight1ID);
+		this.cmd(act.step);
+
+		for (let i = 0; i < this.top; i++) {
+			this.cmd(act.delete, this.arrayID[i]);
+			this.cmd(act.delete, this.arrayLabelID[i]);
+		}
+
+		for (let i = 0; i < this.top * 2; i++) {
+			const xpos = (i % ARRAY_ELEMS_PER_LINE) * ARRAY_ELEM_WIDTH + ARRAY_START_X;
+			const ypos = Math.floor(i / ARRAY_ELEMS_PER_LINE) * ARRAY_LINE_SPACING + ARRAY_START_Y;
+
+			this.cmd(act.move, this.arrayIDNew[i], xpos, ypos);
+			this.cmd(act.move, this.arrayLabelIDNew[i], xpos, ypos + ARRAY_ELEM_HEIGHT);
+		}
+		this.cmd(act.step);
+
+		this.cmd(act.setHighlight, this.topID, 1);
+		this.cmd(act.step);
+
+		this.top = this.top + 1;
+		this.cmd(act.setText, this.topID, this.top);
+		this.cmd(act.delete, labPushID);
+		this.cmd(act.delete, labPushResizeID);
+		this.cmd(act.step);
+
+		this.cmd(act.setHighlight, this.topID, 0);
+
+		this.arrayID = this.arrayIDNew;
+		this.arrayLabelID = this.arrayLabelIDNew;
+		this.arrayData = this.arrayDataNew;
+
+		this.nextIndex = this.nextIndex - this.top + 1;
 
 		return this.commands;
 	}


### PR DESCRIPTION
Closes #61 

Added the ability to resize Stack Arrays when they're full (again, but working this time)
![resizeStackArrayStepBack](https://user-images.githubusercontent.com/64664063/103725035-b6332200-4fa3-11eb-8ed9-db5409759b39.gif)


Actually very much _unlike_ ArrayList resizing contrary to what I mentioned in my last PR. For StackArray, keeping `this.arrayData` works perfectly fine, and everything is reverted properly upon stepping back.


To reiterate, I changed the initial minimum array size to 7 and the maximum amount of resizes to 2. Also, I changed the placement of the new resized array so everything shows up on the screen. Might be a little awkward looking, so I can change if necessary:

![resizeStackArraySize](https://user-images.githubusercontent.com/64664063/103725586-eaf3a900-4fa4-11eb-933a-e192e836a0fb.gif)
