### PR TITLE
Closed Hash Resize

### DIFF
--- a/src/algo/ClosedHash.js
+++ b/src/algo/ClosedHash.js
@@ -395,7 +395,7 @@ export default class ClosedHash extends Hash {
 			this.cmd(
 				act.createLabel,
 				resizeLabel, 
-				`(Resize Required): (Size + 1 / length) > Load Factor --> (${this.size + 1} / ${this.table_size}) / ${this.load_factor}`,
+				`(Resize Required): (Size + 1 / length) > Load Factor --> (${this.size + 1} / ${this.table_size}) > ${this.load_factor}`,
 				RESIZE_LABEL_X,
 				RESIZE_LABEL_Y
 			);

--- a/src/algo/ClosedHash.js
+++ b/src/algo/ClosedHash.js
@@ -134,15 +134,15 @@ export default class ClosedHash extends Hash {
 	insertElement(elem) {
 		this.commands = [];
 
-		this.cmd(act.setText, this.ExplainLabel, 'Inserting element: ' + String(elem));
-		this.cmd(act.step);
-
 		if (
 			(this.size + 1) / this.table_size > this.load_factor
 			&& this.table_size * 2 < MAX_SIZE
 		) {
 			this.resize(false);
 		}
+
+		this.cmd(act.setText, this.ExplainLabel, 'Inserting element: ' + String(elem));
+		this.cmd(act.step);
 
 		let index = this.doHash(elem);
 
@@ -274,15 +274,17 @@ export default class ClosedHash extends Hash {
 		}
 
 		if (!this.empty[index] && this.hashTableValues[index] === elem && !this.deleted[index]) {
+			this.cmd(act.setHighlight, this.hashTableVisual[index], 0);
 			return -1;
 		} else if (probes === this.table_size && removedIndex === -1) {
+			this.cmd(act.setHighlight, this.hashTableVisual[index], 0);
 			return -2;
 		} else {
 			if (removedIndex !== -1) {
 				this.cmd(act.setHighlight, this.hashTableVisual[index], 0);
 				this.cmd(act.setText, this.ExplainLabel, 'Inserting at earlier DEL spot');
 				index = removedIndex;
-			} else if (this.hashTableVisual[index] === elem) {
+			} else if (this.hashTableValues[index] === elem) {
 				this.cmd(act.setText, this.ExplainLabel, 'Inserting at DEL spot with same key')
 			} else {
 				this.cmd(act.setText, this.ExplainLabel, 'Inserting at null spot');
@@ -384,6 +386,9 @@ export default class ClosedHash extends Hash {
 
 	resize(fromCycle) {
 		this.commands = []; 
+
+		this.cmd(act.setText, this.ExplainLabel, '');
+		this.cmd(act.setText, this.DelIndexLabel, '');
 
 		const resizeLabel = this.nextIndex++;
 		if (!fromCycle) {

--- a/src/algo/ClosedHash.js
+++ b/src/algo/ClosedHash.js
@@ -262,8 +262,14 @@ export default class ClosedHash extends Hash {
 					this.ExplainLabel,
 					'Encountered null spot, so terminate loop',
 				);
-				this.cmd(act.step);
+			} else if (this.hashTableValues[index] === elem) {
+				this.cmd(
+					act.setText,
+					this.ExplainLabel,
+					`Encountered matching key, so terminate loop`,
+				);
 			}
+			this.cmd(act.step);
 		}
 
 		this.cmd(act.setText, this.HashIndexID, '');

--- a/src/algo/Hash.js
+++ b/src/algo/Hash.js
@@ -32,7 +32,7 @@ import Algorithm, {
 import { act } from '../anim/AnimationMain';
 
 const MAX_HASH_LENGTH = 10;
-const MAX_LOAD_LENGTH = 3;
+const MAX_LOAD_LENGTH = 2;
 
 const HASH_NUMBER_START_X = 200;
 const HASH_X_DIFF = 7;
@@ -45,11 +45,9 @@ const HASH_ADD_LINE_Y = 42;
 const HASH_RESULT_Y = 50;
 const ELF_HASH_SHIFT = 10;
 
-const HASH_LABEL_X = 300;
-const HASH_LABEL_Y = 50;
+const HASH_LABEL_X = 200;
+const HASH_LABEL_Y = 45;
 const HASH_LABEL_DELTA_X = 50;
-
-const DEFAULT_LOAD_FACTOR = 0.67;
 
 const HIGHLIGHT_COLOR = '#0000FF';
 
@@ -59,7 +57,6 @@ export default class Hash extends Algorithm {
 		this.addControls();
 		this.nextIndex = 0;
 		this.hashingIntegers = true;
-		this.load_factor = DEFAULT_LOAD_FACTOR;
 	}
 
 	addControls() {
@@ -114,6 +111,7 @@ export default class Hash extends Algorithm {
 		addDivisorToAlgorithmBar();
 
 		this.loadField = addControlToAlgorithmBar('Text', '');
+		this.loadField.setAttribute('placeholder', 'LF/100');
 		this.loadField.size = MAX_LOAD_LENGTH;
 		this.loadField.onkeydown = this.returnSubmit(
 			this.loadField,

--- a/src/algo/Hash.js
+++ b/src/algo/Hash.js
@@ -32,6 +32,7 @@ import Algorithm, {
 import { act } from '../anim/AnimationMain';
 
 const MAX_HASH_LENGTH = 10;
+const MAX_LOAD_LENGTH = 3;
 
 const HASH_NUMBER_START_X = 200;
 const HASH_X_DIFF = 7;
@@ -45,8 +46,10 @@ const HASH_RESULT_Y = 50;
 const ELF_HASH_SHIFT = 10;
 
 const HASH_LABEL_X = 300;
-const HASH_LABEL_Y = 30;
+const HASH_LABEL_Y = 50;
 const HASH_LABEL_DELTA_X = 50;
+
+const DEFAULT_LOAD_FACTOR = 0.67;
 
 const HIGHLIGHT_COLOR = '#0000FF';
 
@@ -56,6 +59,7 @@ export default class Hash extends Algorithm {
 		this.addControls();
 		this.nextIndex = 0;
 		this.hashingIntegers = true;
+		this.load_factor = DEFAULT_LOAD_FACTOR;
 	}
 
 	addControls() {
@@ -106,6 +110,23 @@ export default class Hash extends Algorithm {
 		this.findButton = addControlToAlgorithmBar('Button', 'Find');
 		this.findButton.onclick = this.findCallback.bind(this);
 		this.controls.push(this.findButton);
+
+		addDivisorToAlgorithmBar();
+
+		this.loadField = addControlToAlgorithmBar('Text', '');
+		this.loadField.size = MAX_LOAD_LENGTH;
+		this.loadField.onkeydown = this.returnSubmit(
+			this.loadField,
+			this.changeLoadFactor.bind(this),
+			MAX_LOAD_LENGTH,
+			true
+		)
+
+		this.controls.push(this.loadField);
+
+		this.loadButton = addControlToAlgorithmBar('Button', 'Load Factor');
+		this.loadButton.onclick = this.loadFactorCallBack.bind(this);
+		this.controls.push(this.loadButton);
 
 		addDivisorToAlgorithmBar();
 
@@ -534,6 +555,14 @@ export default class Hash extends Algorithm {
 		if (findValue !== '') {
 			this.findField.value = '';
 			this.implementAction(this.findElement.bind(this), findValue);
+		}
+	}
+
+	loadFactorCallBack() {
+		if (this.loadField.value !== '') {
+			const newLF = this.loadField.value / 100;
+			this.loadField.value = '';
+			this.implementAction(this.changeLoadFactor.bind(this), newLF);
 		}
 	}
 

--- a/src/algo/OpenHash.js
+++ b/src/algo/OpenHash.js
@@ -38,6 +38,11 @@ const LINKED_ITEM_Y_DELTA = 50;
 
 const HASH_TABLE_SIZE = 13;
 
+const DEFAULT_LOAD_FACTOR = 0.67;
+
+const LOAD_LABEL_X = 60;
+const LOAD_LABEL_Y = 20;
+
 const INDEX_COLOR = '#0000FF';
 
 export default class OpenHash extends Hash {
@@ -234,6 +239,16 @@ export default class OpenHash extends Hash {
 		return this.commands;
 	}
 
+	changeLoadFactor(LF) {
+		this.commands = [];
+
+		this.load_factor = LF;
+		this.cmd(act.setText, this.loadFactorID, `Load Factor: ${this.load_factor}`);
+		this.cmd(act.step);
+
+		return this.commands;
+	}
+
 	setup() {
 		this.hashTableVisual = new Array(HASH_TABLE_SIZE);
 		this.hashTableIndices = new Array(HASH_TABLE_SIZE);
@@ -244,7 +259,11 @@ export default class OpenHash extends Hash {
 
 		this.ExplainLabel = this.nextIndex++;
 
+		this.loadFactorID = this.nextIndex++;
+
 		this.table_size = HASH_TABLE_SIZE;
+
+		this.load_factor = DEFAULT_LOAD_FACTOR;
 
 		this.commands = [];
 		for (let i = 0; i < HASH_TABLE_SIZE; i++) {
@@ -271,6 +290,7 @@ export default class OpenHash extends Hash {
 			this.cmd(act.createLabel, nextID, i, this.indexXPos[i], this.indexYPos[i]);
 			this.cmd(act.setForegroundColor, nextID, INDEX_COLOR);
 		}
+		this.cmd(act.createLabel, this.loadFactorID, `Load Factor: ${this.load_factor}`, LOAD_LABEL_X, LOAD_LABEL_Y);
 		this.cmd(act.createLabel, this.ExplainLabel, '', 10, 25, 0);
 		this.animationManager.startNewAnimation(this.commands);
 		this.animationManager.skipForward();


### PR DESCRIPTION
Closes #106
Closes #103 
Closes #102 

It's big hashing time

Hashing resize has been implemented (for probing). External hashing to follow soon, and <key, value> pairs after that.
This PR does quiiiite a few things on top of just implementing probing hashmap resize:
- Adds a label that keeps track of the index calculation while probing to give a little more clarification as to how the indices are being reached
- Adds a changeable load factor that dictates when a resize will happen (and yes, you can make this LF 0 for immediate resizes)
- Adds a maximum array size of 55 (for a total of 2 resizes, consistent with the other resize PR's)
- Changes DoubleHashing's prime number to the next lowest prime after each resize (e.g. 23 after the first resize and 53 after the second) [I'm not sure if this was necessary please tell me if I should remove this]
- Makes a looooot of bug fixes and label fixes
![ClosedHashResize](https://user-images.githubusercontent.com/64664063/111551849-864c8b80-8757-11eb-8db8-8bd26eac742b.gif)