### PR TITLE
Improve text handling for algorithms that take array inputs

### DIFF
--- a/src/algo/BubbleSort.js
+++ b/src/algo/BubbleSort.js
@@ -28,9 +28,12 @@ import Algorithm, {
 	addCheckboxToAlgorithmBar,
 	addControlToAlgorithmBar,
 	addDivisorToAlgorithmBar,
-	addLabelToAlgorithmBar,
+	addGroupToAlgorithmBar,
+	addLabelToAlgorithmBar
 } from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
+
+const MAX_ARRAY_SIZE = 18;
 
 const ARRAY_START_X = 100;
 const ARRAY_START_Y = 200;
@@ -50,10 +53,17 @@ export default class BubbleSort extends Algorithm {
 	addControls() {
 		this.controls = [];
 
-		addLabelToAlgorithmBar('Comma separated list (e.g. "3,1,2", max 18 elements)');
+		const verticalGroup = addGroupToAlgorithmBar(false);
 
-		// List text field
-		this.listField = addControlToAlgorithmBar('Text', '');
+        addLabelToAlgorithmBar(
+			'Comma seperated list (e.g. "3,1,2"). Max 18 elements & no elements > 999',
+			verticalGroup
+		);
+
+		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
+
+        // List text field
+		this.listField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.listField.onkeydown = this.returnSubmit(
 			this.listField,
 			this.sortCallback.bind(this),
@@ -63,9 +73,11 @@ export default class BubbleSort extends Algorithm {
 		this.controls.push(this.listField);
 
 		// Sort button
-		this.findButton = addControlToAlgorithmBar('Button', 'Sort');
-		this.findButton.onclick = this.sortCallback.bind(this);
-		this.controls.push(this.findButton);
+		this.sortButton = addControlToAlgorithmBar('Button', 'Sort', horizontalGroup);
+		this.sortButton.onclick = this.sortCallback.bind(this);
+		this.controls.push(this.sortButton);
+
+		addDivisorToAlgorithmBar();
 
 		// Clear button
 		this.clearButton = addControlToAlgorithmBar('Button', 'Clear');
@@ -102,9 +114,14 @@ export default class BubbleSort extends Algorithm {
 	}
 
 	sortCallback() {
-		if (this.listField.value !== '') {
+		const list = this.listField.value.split(',').filter(x => x !== '');
+		console.log(list);
+		if (
+			this.listField.value !== ''
+			&& list.length <= MAX_ARRAY_SIZE
+			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+		) {
 			this.implementAction(this.clear.bind(this));
-			const list = this.listField.value;
 			this.listField.value = '';
 			this.implementAction(this.sort.bind(this), list);
 		}
@@ -134,10 +151,9 @@ export default class BubbleSort extends Algorithm {
 
 		this.arrayID = [];
 		this.arrayData = params
-			.split(',')
 			.map(Number)
 			.filter(x => !Number.isNaN(x))
-			.slice(0, 18);
+			.slice(0, MAX_ARRAY_SIZE);
 		const length = this.arrayData.length;
 		const elemCounts = new Map();
 		const letterMap = new Map();

--- a/src/algo/CocktailSort.js
+++ b/src/algo/CocktailSort.js
@@ -28,9 +28,12 @@ import Algorithm, {
 	addCheckboxToAlgorithmBar,
 	addControlToAlgorithmBar,
 	addDivisorToAlgorithmBar,
-	addLabelToAlgorithmBar,
+	addGroupToAlgorithmBar,
+	addLabelToAlgorithmBar
 } from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
+
+const MAX_ARRAY_SIZE = 18;
 
 const ARRAY_START_X = 100;
 const ARRAY_START_Y = 200;
@@ -50,10 +53,17 @@ export default class CocktailSort extends Algorithm {
 	addControls() {
 		this.controls = [];
 
-		addLabelToAlgorithmBar('Comma separated list (e.g. "3,1,2", max 18 elements)');
+		const verticalGroup = addGroupToAlgorithmBar(false);
 
-		// List text field
-		this.listField = addControlToAlgorithmBar('Text', '');
+        addLabelToAlgorithmBar(
+			'Comma seperated list (e.g. "3,1,2"). Max 18 elements & no elements > 999',
+			verticalGroup
+		);
+
+		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
+
+        // List text field
+		this.listField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.listField.onkeydown = this.returnSubmit(
 			this.listField,
 			this.sortCallback.bind(this),
@@ -63,9 +73,11 @@ export default class CocktailSort extends Algorithm {
 		this.controls.push(this.listField);
 
 		// Sort button
-		this.findButton = addControlToAlgorithmBar('Button', 'Sort');
-		this.findButton.onclick = this.sortCallback.bind(this);
-		this.controls.push(this.findButton);
+		this.sortButton = addControlToAlgorithmBar('Button', 'Sort', horizontalGroup);
+		this.sortButton.onclick = this.sortCallback.bind(this);
+		this.controls.push(this.sortButton);
+
+		addDivisorToAlgorithmBar();
 
 		// Clear button
 		this.clearButton = addControlToAlgorithmBar('Button', 'Clear');
@@ -102,9 +114,13 @@ export default class CocktailSort extends Algorithm {
 	}
 
 	sortCallback() {
-		if (this.listField.value !== '') {
+		const list = this.listField.value.split(',').filter(x => x !== '');
+		if (
+			this.listField.value !== ''
+			&& list.length <= MAX_ARRAY_SIZE
+			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+			) {
 			this.implementAction(this.clear.bind(this));
-			const list = this.listField.value;
 			this.listField.value = '';
 			this.implementAction(this.sort.bind(this), list);
 		}
@@ -133,10 +149,9 @@ export default class CocktailSort extends Algorithm {
 
 		this.arrayID = [];
 		this.arrayData = params
-			.split(',')
 			.map(Number)
 			.filter(x => !Number.isNaN(x))
-			.slice(0, 18);
+			.slice(0, MAX_ARRAY_SIZE);
 		this.displayData = new Array(this.arrayData.length);
 		const length = this.arrayData.length;
 

--- a/src/algo/Heap.js
+++ b/src/algo/Heap.js
@@ -33,6 +33,8 @@ import Algorithm, {
 } from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
 
+const MAX_ARRAY_SIZE = 31;
+
 const ARRAY_SIZE = 32;
 const ARRAY_ELEM_WIDTH = 30;
 const ARRAY_ELEM_HEIGHT = 25;
@@ -121,6 +123,8 @@ export default class Heap extends Algorithm {
 	}
 
 	addControls() {
+		this.controls = [];
+
 		this.insertField = addControlToAlgorithmBar('Text', '');
 		this.insertField.onkeydown = this.returnSubmit(
 			this.insertField,
@@ -128,26 +132,24 @@ export default class Heap extends Algorithm {
 			4,
 			true,
 		);
+		this.controls.push(this.insertField);
 
 		this.insertButton = addControlToAlgorithmBar('Button', 'Enqueue');
 		this.insertButton.onclick = this.insertCallback.bind(this);
+		this.controls.push(this.insertButton);
 
 		addDivisorToAlgorithmBar();
 
 		this.removeButton = addControlToAlgorithmBar('Button', 'Dequeue');
 		this.removeButton.onclick = this.removeCallback.bind(this);
-
-		addDivisorToAlgorithmBar();
-
-		this.clearButton = addControlToAlgorithmBar('Button', 'Clear');
-		this.clearButton.onclick = this.clearCallback.bind(this);
+		this.controls.push(this.removeButton);
 
 		addDivisorToAlgorithmBar();
 
 		const verticalGroup = addGroupToAlgorithmBar(false);
 
 		addLabelToAlgorithmBar(
-			'Comma separated list (e.g. "3,1,2", max 31 elements)',
+			'Comma separated list (e.g. "3,1,2"). Max 31 elements & no elements > 999',
 			verticalGroup,
 		);
 
@@ -157,12 +159,20 @@ export default class Heap extends Algorithm {
 		this.buildHeapField.onkeydown = this.returnSubmit(
 			this.buildHeapField,
 			this.buildHeapCallback.bind(this),
-			61,
+			60,
 			false,
 		);
+		this.controls.push(this.buildHeapField);
 
 		this.buildHeapButton = addControlToAlgorithmBar('Button', 'BuildHeap', horizontalGroup);
 		this.buildHeapButton.onclick = this.buildHeapCallback.bind(this);
+		this.controls.push(this.buildHeapButton);
+
+		addDivisorToAlgorithmBar();
+
+		this.clearButton = addControlToAlgorithmBar('Button', 'Clear');
+		this.clearButton.onclick = this.clearCallback.bind(this);
+		this.controls.push(this.clearButton);
 
 		addDivisorToAlgorithmBar();
 
@@ -177,6 +187,8 @@ export default class Heap extends Algorithm {
 		this.maxHeapButton = minMaxButtonList[1];
 		this.maxHeapButton.onclick = this.maxHeapCallback.bind(this);
 		this.isMinHeap = true;
+		this.controls.push(this.minHeapButton);
+		this.controls.push(this.maxHeapButton);
 	}
 
 	createArray() {
@@ -242,8 +254,12 @@ export default class Heap extends Algorithm {
 	}
 
 	buildHeapCallback() {
-		if (this.buildHeapField.value !== '') {
-			const list = this.buildHeapField.value;
+		const list = this.buildHeapField.value.split(',').filter(x => x !== '');
+		if (
+			this.buildHeapField.value !== ''
+			&& list.length <= MAX_ARRAY_SIZE
+			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+			) {
 			this.buildHeapField.value = '';
 			this.implementAction(this.buildHeap.bind(this), list);
 		}
@@ -433,10 +449,9 @@ export default class Heap extends Algorithm {
 	buildHeap(params) {
 		this.commands = [];
 		this.arrayData = params
-			.split(',') // Split on commas
 			.map(Number) // Map to numbers (to remove invalid characters)
 			.filter(x => !Number.isNaN(x)) // Remove stuff that was invalid
-			.slice(0, 31); // Get first 31 numbers
+			.slice(0, MAX_ARRAY_SIZE); // Get first 31 numbers
 		this.arrayData.unshift(0); // Add a 0 to start of array
 		this.clear();
 		for (let i = 1; i < this.arrayData.length; i++) {
@@ -543,22 +558,10 @@ export default class Heap extends Algorithm {
 	}
 
 	disableUI() {
-		this.insertField.disabled = true;
-		this.insertButton.disabled = true;
-		this.removeButton.disabled = true;
-		this.clearButton.disabled = true;
-		this.buildHeapButton.disabled = true;
-		this.minHeapButton.disabled = true;
-		this.maxHeapButton.disabled = true;
+		this.controls.forEach(button => button.disabled = true);
 	}
 
 	enableUI() {
-		this.insertField.disabled = false;
-		this.insertButton.disabled = false;
-		this.removeButton.disabled = false;
-		this.clearButton.disabled = false;
-		this.buildHeapButton.disabled = false;
-		this.minHeapButton.disabled = false;
-		this.maxHeapButton.disabled = false;
+		this.controls.forEach(button => button.disabled = false);
 	}
 }

--- a/src/algo/HeapSort.js
+++ b/src/algo/HeapSort.js
@@ -26,9 +26,13 @@
 
 import Algorithm, {
 	addControlToAlgorithmBar,
+	addDivisorToAlgorithmBar,
+	addGroupToAlgorithmBar,
 	addLabelToAlgorithmBar,
 } from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
+
+const MAX_ARRAY_SIZE = 15;
 
 const INFO_MSG_X = 20;
 const INFO_MSG_Y = 150;
@@ -129,10 +133,17 @@ export default class HeapSort extends Algorithm {
     addControls() {
         this.controls = [];
 
-        addLabelToAlgorithmBar('Comma seperated list (e.g. "3,1,2", max 15 elements, no elements > 999)');
+		const verticalGroup = addGroupToAlgorithmBar(false);
+
+        addLabelToAlgorithmBar(
+			'Comma seperated list (e.g. "3,1,2"). Max 15 elements & no elements > 999',
+			verticalGroup
+		);
+
+		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
 
         // List text field
-		this.listField = addControlToAlgorithmBar('Text', '');
+		this.listField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.listField.onkeydown = this.returnSubmit(
 			this.listField,
 			this.sortCallback.bind(this),
@@ -142,9 +153,11 @@ export default class HeapSort extends Algorithm {
 		this.controls.push(this.listField);
 
 		// Sort button
-		this.sortButton = addControlToAlgorithmBar('Button', 'Sort');
+		this.sortButton = addControlToAlgorithmBar('Button', 'Sort', horizontalGroup);
 		this.sortButton.onclick = this.sortCallback.bind(this);
 		this.controls.push(this.sortButton);
+
+		addDivisorToAlgorithmBar();
 
 		// Clear button
 		this.clearButton = addControlToAlgorithmBar('Button', 'Clear');
@@ -208,10 +221,9 @@ export default class HeapSort extends Algorithm {
 		this.cmd(act.setHighlight, this.codeID[0][0], 1);
 
         this.arrayData = list
-			.split(',')
 			.map(Number)
 			.filter(x => !Number.isNaN(x))
-			.slice(0, 15);
+			.slice(0, MAX_ARRAY_SIZE);
         const length = this.arrayData.length;
 		const displayDataTemp = new Array(length);
 		const elemCounts = new Map();
@@ -547,13 +559,13 @@ export default class HeapSort extends Algorithm {
     }
 
     sortCallback() {
-		const listValue = this.listField.value.split(',')
+		const list = this.listField.value.split(',').filter(x => x !== '');
         if (
 			this.listField.value !== ''
-			&& listValue.length <= 15
-			&& listValue.map(Number).filter(x => x > 999).length <= 0) {
+			&& list.length <= MAX_ARRAY_SIZE
+			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+			) {
             this.implementAction(this.clear.bind(this));
-            const list = this.listField.value;
             this.listField.value = '';
             this.implementAction(this.sort.bind(this), list);
         }

--- a/src/algo/InsertionSort.js
+++ b/src/algo/InsertionSort.js
@@ -24,8 +24,15 @@
 // authors and should not be interpreted as representing official policies, either expressed
 // or implied, of the University of San Francisco
 
-import Algorithm, { addControlToAlgorithmBar, addLabelToAlgorithmBar } from './Algorithm.js';
+import Algorithm, { 
+	addControlToAlgorithmBar,
+	addDivisorToAlgorithmBar,
+	addGroupToAlgorithmBar,
+	addLabelToAlgorithmBar 
+} from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
+
+const MAX_ARRAY_SIZE = 18;
 
 const ARRAY_START_X = 100;
 const ARRAY_START_Y = 200;
@@ -43,10 +50,17 @@ export default class InsertionSort extends Algorithm {
 	addControls() {
 		this.controls = [];
 
-		addLabelToAlgorithmBar('Comma seperated list (e.g. "3,1,2", max 18 elements)');
+		const verticalGroup = addGroupToAlgorithmBar(false);
 
-		// List text field
-		this.listField = addControlToAlgorithmBar('Text', '');
+        addLabelToAlgorithmBar(
+			'Comma seperated list (e.g. "3,1,2"). Max 18 elements & no elements > 999',
+			verticalGroup
+		);
+
+		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
+
+        // List text field
+		this.listField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.listField.onkeydown = this.returnSubmit(
 			this.listField,
 			this.sortCallback.bind(this),
@@ -56,9 +70,11 @@ export default class InsertionSort extends Algorithm {
 		this.controls.push(this.listField);
 
 		// Sort button
-		this.findButton = addControlToAlgorithmBar('Button', 'Sort');
-		this.findButton.onclick = this.sortCallback.bind(this);
-		this.controls.push(this.findButton);
+		this.sortButton = addControlToAlgorithmBar('Button', 'Sort', horizontalGroup);
+		this.sortButton.onclick = this.sortCallback.bind(this);
+		this.controls.push(this.sortButton);
+
+		addDivisorToAlgorithmBar();
 
 		// Clear button
 		this.clearButton = addControlToAlgorithmBar('Button', 'Clear');
@@ -88,9 +104,13 @@ export default class InsertionSort extends Algorithm {
 	}
 
 	sortCallback() {
-		if (this.listField.value !== '') {
+		const list = this.listField.value.split(',').filter(x => x !== '');
+		if (
+			this.listField.value !== ''
+			&& list.length <= MAX_ARRAY_SIZE
+			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+			) {
 			this.implementAction(this.clear.bind(this));
-			const list = this.listField.value;
 			this.listField.value = '';
 			this.implementAction(this.sort.bind(this), list);
 		}
@@ -116,10 +136,9 @@ export default class InsertionSort extends Algorithm {
 
 		this.arrayID = [];
 		this.arrayData = params
-			.split(',')
 			.map(Number)
 			.filter(x => !Number.isNaN(x))
-			.slice(0, 18);
+			.slice(0, MAX_ARRAY_SIZE);
 		this.displayData = new Array(this.arrayData.length);
 		const length = this.arrayData.length;
 		const elemCounts = new Map();

--- a/src/algo/LSDRadix.js
+++ b/src/algo/LSDRadix.js
@@ -24,8 +24,15 @@
 // authors and should not be interpreted as representing official policies, either expressed
 // or implied, of the University of San Francisco
 
-import Algorithm, { addControlToAlgorithmBar, addLabelToAlgorithmBar } from './Algorithm.js';
+import Algorithm, { 
+	addControlToAlgorithmBar,
+	addDivisorToAlgorithmBar,
+	addGroupToAlgorithmBar,
+	addLabelToAlgorithmBar,
+ } from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
+
+const MAX_ARRAY_SIZE = 18;
 
 const INFO_LABEL_X = 75;
 const INFO_LABEL_Y = 20;
@@ -54,10 +61,17 @@ export default class LSDRadix extends Algorithm {
 	addControls() {
 		this.controls = [];
 
-		addLabelToAlgorithmBar('Comma separated list (e.g. "3,1,2", max 9 elements)');
+		const verticalGroup = addGroupToAlgorithmBar(false);
 
-		// List text field
-		this.listField = addControlToAlgorithmBar('Text', '');
+        addLabelToAlgorithmBar(
+			'Comma seperated list (e.g. "3,1,2"). Max 18 elements & no elements < 0',
+			verticalGroup
+		);
+
+		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
+
+        // List text field
+		this.listField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.listField.onkeydown = this.returnSubmit(
 			this.listField,
 			this.sortCallback.bind(this),
@@ -67,9 +81,11 @@ export default class LSDRadix extends Algorithm {
 		this.controls.push(this.listField);
 
 		// Sort button
-		this.findButton = addControlToAlgorithmBar('Button', 'Sort');
-		this.findButton.onclick = this.sortCallback.bind(this);
-		this.controls.push(this.findButton);
+		this.sortButton = addControlToAlgorithmBar('Button', 'Sort', horizontalGroup);
+		this.sortButton.onclick = this.sortCallback.bind(this);
+		this.controls.push(this.sortButton);
+
+		addDivisorToAlgorithmBar();
 
 		// Clear button
 		this.clearButton = addControlToAlgorithmBar('Button', 'Clear');
@@ -107,9 +123,13 @@ export default class LSDRadix extends Algorithm {
 	}
 
 	sortCallback() {
-		if (this.listField.value !== '') {
+		const list = this.listField.value.split(',').filter(x => x !== '');
+		if (
+			this.listField.value !== ''
+			&& list.length <= MAX_ARRAY_SIZE
+			&& list.map(Number).filter(x => Number.isNaN(x)).length <= 0
+			) {
 			this.implementAction(this.clear.bind(this));
-			const list = this.listField.value;
 			this.listField.value = '';
 			this.implementAction(this.sort.bind(this), list);
 		}
@@ -143,10 +163,9 @@ export default class LSDRadix extends Algorithm {
 
 		this.arrayID = [];
 		this.arrayData = params
-			.split(',')
 			.map(Number)
 			.filter(x => !Number.isNaN(x))
-			.slice(0, 9);
+			.slice(0, MAX_ARRAY_SIZE);
 		const length = this.arrayData.length;
 		const elemCounts = new Map();
 		const letterMap = new Map();

--- a/src/algo/MergeSort.js
+++ b/src/algo/MergeSort.js
@@ -24,8 +24,15 @@
 // authors and should not be interpreted as representing official policies, either expressed
 // or implied, of the University of San Francisco
 
-import Algorithm, { addControlToAlgorithmBar, addLabelToAlgorithmBar } from './Algorithm.js';
+import Algorithm, { 
+	addControlToAlgorithmBar,
+	addDivisorToAlgorithmBar,
+	addGroupToAlgorithmBar,
+	addLabelToAlgorithmBar 
+} from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
+
+const MAX_ARRAY_SIZE = 18;
 
 const ARRAY_START_X = 120;
 const ARRAY_START_Y = 50;
@@ -67,10 +74,17 @@ export default class MergeSort extends Algorithm {
 	addControls() {
 		this.controls = [];
 
-		addLabelToAlgorithmBar('Comma separated list (e.g. "3,1,2", max 12 elements)');
+		const verticalGroup = addGroupToAlgorithmBar(false);
 
-		// List text field
-		this.listField = addControlToAlgorithmBar('Text', '');
+        addLabelToAlgorithmBar(
+			'Comma seperated list (e.g. "3,1,2"). Max 18 elements & no elements > 999',
+			verticalGroup
+		);
+
+		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
+
+        // List text field
+		this.listField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.listField.onkeydown = this.returnSubmit(
 			this.listField,
 			this.sortCallback.bind(this),
@@ -80,9 +94,11 @@ export default class MergeSort extends Algorithm {
 		this.controls.push(this.listField);
 
 		// Sort button
-		this.findButton = addControlToAlgorithmBar('Button', 'Sort');
-		this.findButton.onclick = this.sortCallback.bind(this);
-		this.controls.push(this.findButton);
+		this.sortButton = addControlToAlgorithmBar('Button', 'Sort', horizontalGroup);
+		this.sortButton.onclick = this.sortCallback.bind(this);
+		this.controls.push(this.sortButton);
+
+		addDivisorToAlgorithmBar();
 
 		// Clear button
 		this.clearButton = addControlToAlgorithmBar('Button', 'Clear');
@@ -108,9 +124,13 @@ export default class MergeSort extends Algorithm {
 	}
 
 	sortCallback() {
-		if (this.listField.value !== '') {
+		const list = this.listField.value.split(',').filter(x => x !== '');
+		if (
+			this.listField.value !== ''
+			&& list.length <= MAX_ARRAY_SIZE
+			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+			) {
 			this.implementAction(this.clear.bind(this));
-			const list = this.listField.value;
 			this.listField.value = '';
 			this.implementAction(this.sort.bind(this), list);
 		}
@@ -136,10 +156,9 @@ export default class MergeSort extends Algorithm {
 
 		this.arrayID = [];
 		this.arrayData = params
-			.split(',')
 			.map(Number)
 			.filter(x => !Number.isNaN(x))
-			.slice(0, 12);
+			.slice(0, MAX_ARRAY_SIZE);
 		this.displayData = new Array(this.arrayData.length);
 
 		const elemCounts = new Map();

--- a/src/algo/QuickSelect.js
+++ b/src/algo/QuickSelect.js
@@ -27,10 +27,13 @@
 import Algorithm, {
 	addControlToAlgorithmBar,
 	addDivisorToAlgorithmBar,
+	addGroupToAlgorithmBar,
 	addLabelToAlgorithmBar,
 	addRadioButtonGroupToAlgorithmBar,
 } from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
+
+const MAX_ARRAY_SIZE = 18;
 
 const ARRAY_START_X = 100;
 const ARRAY_START_Y = 200;
@@ -48,22 +51,29 @@ export default class QuickSelect extends Algorithm {
 	addControls() {
 		this.controls = [];
 
-		addLabelToAlgorithmBar('Comma separated list (e.g. "3,1,2", max 18 elements)');
+		const verticalGroup = addGroupToAlgorithmBar(false);
 
-		// List text field
-		this.listField = addControlToAlgorithmBar('Text', '');
+        addLabelToAlgorithmBar(
+			`Comma seperated list (e.g. "3,1,2"). Max ${MAX_ARRAY_SIZE} elements & no elements > 999`,
+			verticalGroup
+		);
+
+		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
+
+        // List text field
+		this.listField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.listField.onkeydown = this.returnSubmit(
 			this.listField,
 			this.runCallback.bind(this),
-			60,
+			90,
 			false,
 		);
 		this.controls.push(this.listField);
 
-		addLabelToAlgorithmBar('kᵗʰ element (1 indexed)');
+		addLabelToAlgorithmBar('kᵗʰ element (1 indexed)', horizontalGroup);
 
 		// k text field
-		this.kField = addControlToAlgorithmBar('Text', '');
+		this.kField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.kField.onkeydown = this.returnSubmit(
 			this.kField,
 			this.runCallback.bind(this),
@@ -73,14 +83,9 @@ export default class QuickSelect extends Algorithm {
 		this.controls.push(this.kField);
 
 		// Run button
-		this.findButton = addControlToAlgorithmBar('Button', 'Run');
+		this.findButton = addControlToAlgorithmBar('Button', 'Run', horizontalGroup);
 		this.findButton.onclick = this.runCallback.bind(this);
 		this.controls.push(this.findButton);
-
-		// Clear button
-		this.clearButton = addControlToAlgorithmBar('Button', 'Clear');
-		this.clearButton.onclick = this.clearCallback.bind(this);
-		this.controls.push(this.clearButton);
 
 		addDivisorToAlgorithmBar();
 
@@ -102,6 +107,11 @@ export default class QuickSelect extends Algorithm {
 		this.pivotType = 'random';
 
 		addDivisorToAlgorithmBar();
+		
+		// Clear button
+		this.clearButton = addControlToAlgorithmBar('Button', 'Clear');
+		this.clearButton.onclick = this.clearCallback.bind(this);
+		this.controls.push(this.clearButton);
 	}
 
 	setup() {
@@ -128,19 +138,19 @@ export default class QuickSelect extends Algorithm {
 	}
 
 	runCallback() {
-		if (this.listField.value !== '' && this.kField.value !== '') {
-			const listStr = this.listField.value;
-			const list = listStr
-				.split(',')
-				.map(Number)
-				.filter(x => !Number.isNaN(x))
-				.slice(0, 18);
+		const list = this.listField.value.split(',').filter(x => x !== '');
+		if (
+			this.listField.value !== '' 
+			&& this.kField.value !== ''
+			&& list.length <= MAX_ARRAY_SIZE
+			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+			) {
 			const k = this.kField.value;
 			if (k > 0 && k <= list.length) {
 				this.implementAction(this.clear.bind(this));
 				this.listField.value = '';
 				this.kField.value = '';
-				this.implementAction(this.run.bind(this), listStr, k);
+				this.implementAction(this.run.bind(this), list, k);
 			}
 		}
 	}
@@ -167,7 +177,6 @@ export default class QuickSelect extends Algorithm {
 
 		this.arrayID = [];
 		this.arrayData = list
-			.split(',')
 			.map(Number)
 			.filter(x => !Number.isNaN(x))
 			.slice(0, 18);

--- a/src/algo/QuickSort.js
+++ b/src/algo/QuickSort.js
@@ -27,10 +27,13 @@
 import Algorithm, {
 	addControlToAlgorithmBar,
 	addDivisorToAlgorithmBar,
+	addGroupToAlgorithmBar,
 	addLabelToAlgorithmBar,
 	addRadioButtonGroupToAlgorithmBar,
 } from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
+
+const MAX_ARRAY_SIZE = 18;
 
 const ARRAY_START_X = 100;
 const ARRAY_START_Y = 200;
@@ -48,10 +51,17 @@ export default class QuickSort extends Algorithm {
 	addControls() {
 		this.controls = [];
 
-		addLabelToAlgorithmBar('Comma separated list (e.g. "3,1,2", max 18 elements)');
+		const verticalGroup = addGroupToAlgorithmBar(false);
 
-		// List text field
-		this.listField = addControlToAlgorithmBar('Text', '');
+        addLabelToAlgorithmBar(
+			'Comma seperated list (e.g. "3,1,2"). Max 18 elements & no elements > 999',
+			verticalGroup
+		);
+
+		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
+
+        // List text field
+		this.listField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.listField.onkeydown = this.returnSubmit(
 			this.listField,
 			this.sortCallback.bind(this),
@@ -61,9 +71,11 @@ export default class QuickSort extends Algorithm {
 		this.controls.push(this.listField);
 
 		// Sort button
-		this.findButton = addControlToAlgorithmBar('Button', 'Sort');
-		this.findButton.onclick = this.sortCallback.bind(this);
-		this.controls.push(this.findButton);
+		this.sortButton = addControlToAlgorithmBar('Button', 'Sort', horizontalGroup);
+		this.sortButton.onclick = this.sortCallback.bind(this);
+		this.controls.push(this.sortButton);
+
+		addDivisorToAlgorithmBar();
 
 		// Clear button
 		this.clearButton = addControlToAlgorithmBar('Button', 'Clear');
@@ -116,9 +128,13 @@ export default class QuickSort extends Algorithm {
 	}
 
 	sortCallback() {
-		if (this.listField.value !== '') {
+		const list = this.listField.value.split(',').filter(x => x !== '');
+		if (
+			this.listField.value !== ''
+			&& list.length <= MAX_ARRAY_SIZE
+			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+			) {
 			this.implementAction(this.clear.bind(this));
-			const list = this.listField.value;
 			this.listField.value = '';
 			this.implementAction(this.sort.bind(this), list);
 		}
@@ -144,10 +160,9 @@ export default class QuickSort extends Algorithm {
 
 		this.arrayID = [];
 		this.arrayData = params
-			.split(',')
 			.map(Number)
-			.filter(x => x)
-			.slice(0, 18);
+			.filter(x => !Number.isNaN(x))
+			.slice(0, MAX_ARRAY_SIZE);
 		this.displayData = new Array(this.arrayData.length);
 
 		const elemCounts = new Map();

--- a/src/algo/SelectionSort.js
+++ b/src/algo/SelectionSort.js
@@ -27,10 +27,13 @@
 import Algorithm, {
 	addControlToAlgorithmBar,
 	addDivisorToAlgorithmBar,
+	addGroupToAlgorithmBar,
 	addLabelToAlgorithmBar,
 	addRadioButtonGroupToAlgorithmBar,
 } from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
+
+const MAX_ARRAY_SIZE = 18;
 
 const ARRAY_START_X = 100;
 const ARRAY_START_Y = 200;
@@ -63,22 +66,31 @@ export default class SelectionSort extends Algorithm {
 	addControls() {
 		this.controls = [];
 
-		addLabelToAlgorithmBar('Comma separated list (e.g. "3,1,2", max 18 elements)');
+		const verticalGroup = addGroupToAlgorithmBar(false);
 
-		// List text field
-		this.listField = addControlToAlgorithmBar('Text', '');
+        addLabelToAlgorithmBar(
+			'Comma seperated list (e.g. "3,1,2"). Max 18 elements & no elements > 999',
+			verticalGroup
+		);
+
+		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
+
+        // List text field
+		this.listField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.listField.onkeydown = this.returnSubmit(
 			this.listField,
 			this.sortCallback.bind(this),
-			60,
+			90,
 			false,
 		);
 		this.controls.push(this.listField);
 
 		// Sort button
-		this.sortButton = addControlToAlgorithmBar('Button', 'Sort');
+		this.sortButton = addControlToAlgorithmBar('Button', 'Sort', horizontalGroup);
 		this.sortButton.onclick = this.sortCallback.bind(this);
 		this.controls.push(this.sortButton);
+
+		addDivisorToAlgorithmBar();
 
 		// Clear button
 		this.clearButton = addControlToAlgorithmBar('Button', 'Clear');
@@ -134,9 +146,13 @@ export default class SelectionSort extends Algorithm {
 	}
 
 	sortCallback() {
-		if (this.listField.value !== '') {
+		const list = this.listField.value.split(',').filter(x => x !== '');
+		if (
+			this.listField.value !== ''
+			&& list.length <= MAX_ARRAY_SIZE
+			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+			) {
 			this.implementAction(this.clear.bind(this));
-			const list = this.listField.value;
 			this.listField.value = '';
 			this.implementAction(this.sort.bind(this), list);
 		}
@@ -162,10 +178,9 @@ export default class SelectionSort extends Algorithm {
 
 		this.arrayID = [];
 		this.arrayData = params
-			.split(',')
 			.map(Number)
 			.filter(x => !Number.isNaN(x))
-			.slice(0, 18);
+			.slice(0, MAX_ARRAY_SIZE);
 		const length = this.arrayData.length;
 		this.displayData = new Array(length);
 


### PR DESCRIPTION
Closes #49  

This PR seeks to improve how text input is handled in the vis tool. 

Essentially, more processing is done after the array is inputted and then the array is either accepted or rejected. For all of these, a check has been added ensuring there are no other characters in the array, as well as no characters greater than the specified value (999 for visual clarity), and no more characters than the amount of elements specified (18 in the case of most sorting algorithms).

There is also a slight visual update with this change, having the text input boxes show up directly below their respective text instead of adjacent to it:
![image](https://user-images.githubusercontent.com/64664063/138707804-de136d6f-502a-4b05-b84c-0d5367505664.png)
^Given this example, you would not be able to input text, since there is a non-integer character in the requested array

Affected algorithms: 
- Heaps/PQs
- Bubble Sort
- Cocktail Shaker Sort
- Insertion Sort
- Selection Sort
- LSD Radix Sort
- Merge Sort
- Quick Sort
- Quick Select
- Heap Sort