### PR TITLE
Update pseudocode for LCS and MergeSort, add more pseudocode for LCS

### DIFF
--- a/src/algo/HeapSort.js
+++ b/src/algo/HeapSort.js
@@ -39,6 +39,7 @@ const INFO_MSG_Y = 150;
 const CODE_START_X = 25;
 const CODE_START_Y = 35;
 const CODE_LINE_HEIGHT = 14;
+const CODE_HIGHLIGHT_COLOR = '#FF0000';
 const CODE_STANDARD_COLOR = '#000000';
 
 const ARRAY_ELEM_WIDTH = 50;
@@ -183,7 +184,7 @@ export default class HeapSort extends Algorithm {
 		this.code = [
 			['procedure heapSort(array)'],
 			['     heap <- create new PriorityQueue(array)'],
-			['     for i <- 0, array.length - 1 do'],
+			['     for i <- 0, array.length - 1, loop:'],
 			['          add ', 'heap.remove()', ' to data[i]'],
 			['     end for'],
 			['end procedure']
@@ -218,7 +219,7 @@ export default class HeapSort extends Algorithm {
     sort(list) {
         this.commands = [];
 
-		this.cmd(act.setHighlight, this.codeID[0][0], 1);
+		this.highlight(0, 0);
 
         this.arrayData = list
 			.map(Number)
@@ -261,10 +262,10 @@ export default class HeapSort extends Algorithm {
 		}
         this.arrayData = displayDataTemp;
         this.cmd(act.step);
-		this.cmd(act.setHighlight, this.codeID[0][0], 0);
+		this.unhighlight(0, 0);
 
         //Create a new heap
-		this.cmd(act.setHighlight, this.codeID[1][0], 1);
+		this.highlight(1, 0);
         this.createHeap(this.arrayData);
         this.cmd(act.step);
 
@@ -277,19 +278,19 @@ export default class HeapSort extends Algorithm {
 		}
         this.cmd(act.step);
 
-		this.cmd(act.setHighlight, this.codeID[1][0], 0);
+		this.unhighlight(1, 0);
 		this.cmd(act.setText, this.infoLabelID, '');
 		
 
         //Remove all of the elements from the heap
         while (this.currentHeapSize > 0) {
-			this.cmd(act.setHighlight, this.codeID[2][0], 1);
+			this.highlight(2, 0);
 			this.cmd(act.step);
-			this.cmd(act.setHighlight, this.codeID[2][0], 0);
+			this.unhighlight(2, 0);
             this.remove();
 		}
 
-		this.cmd(act.setHighlight, this.codeID[4][0], 1);
+		this.highlight(4, 0);
 		this.cmd(act.setText, this.infoLabelID, '');
 		this.cmd(act.step);
 
@@ -297,11 +298,11 @@ export default class HeapSort extends Algorithm {
             this.cmd(act.delete, this.heapArrayID[i]);
             this.cmd(act.delete, this.heapArrayLabelID[i]);
         }
-		this.cmd(act.setHighlight, this.codeID[4][0], 0);
-		this.cmd(act.setHighlight, this.codeID[5][0], 1);
+		this.unhighlight(4, 0);
+		this.highlight(5, 0);
 		this.cmd(act.step);
 	
-		this.cmd(act.setHighlight, this.codeID[5][0], 0);
+		this.unhighlight(5, 0);
 
         return this.commands;
     }
@@ -366,9 +367,9 @@ export default class HeapSort extends Algorithm {
 
 		this.cmd(act.setText, this.infoLabelID, '');
 
-		this.cmd(act.setHighlight, this.codeID[3][0], 1);
-		this.cmd(act.setHighlight, this.codeID[3][1], 1);
-		this.cmd(act.setHighlight, this.codeID[3][2], 1);
+		this.highlight(3, 0);
+		this.highlight(3, 1);
+		this.highlight(3, 2);
 
 		this.cmd(act.setText, this.heapArrayID[1], '');
 
@@ -397,8 +398,8 @@ export default class HeapSort extends Algorithm {
 
 		this.heapArrayData[1] = '';
 		
-		this.cmd(act.setHighlight, this.codeID[3][0], 0);
-		this.cmd(act.setHighlight, this.codeID[3][2], 0);
+		this.unhighlight(3, 0);
+		this.unhighlight(3, 2);
 		this.cmd(act.setText, this.infoLabelID, 'Downheap to maintain order');
 
 		if (this.currentHeapSize > 1) {
@@ -425,7 +426,7 @@ export default class HeapSort extends Algorithm {
 			this.cmd(act.step);
 			this.currentHeapSize--;
 		}
-		this.cmd(act.setHighlight, this.codeID[3][1], 0);
+		this.unhighlight(3, 1);
 		this.cmd(act.step);
 
 		return this.commands;
@@ -574,6 +575,14 @@ export default class HeapSort extends Algorithm {
     clearCallback() {
         this.implementAction(this.clear.bind(this));
     }
+
+	highlight(ind1, ind2) {
+		this.cmd(act.setForegroundColor, this.codeID[ind1][ind2], CODE_HIGHLIGHT_COLOR);
+	}
+
+	unhighlight(ind1, ind2) {
+		this.cmd(act.setForegroundColor, this.codeID[ind1][ind2], CODE_STANDARD_COLOR);
+	}
 
     disableUI() {
 		for (let i = 0; i < this.controls.length; i++) {

--- a/src/algo/LCS.js
+++ b/src/algo/LCS.js
@@ -28,7 +28,7 @@ import Algorithm, { addControlToAlgorithmBar, addLabelToAlgorithmBar } from './A
 import { act } from '../anim/AnimationMain';
 
 const INFO_MSG_X = 20;
-const INFO_MSG_Y = 10;
+const INFO_MSG_Y = 400;
 
 const TABLE_ELEM_WIDTH = 40;
 const TABLE_ELEM_HEIGHT = 30;
@@ -37,7 +37,7 @@ const TABLE_START_X = 500;
 const TABLE_START_Y = 80;
 
 const CODE_START_X = 20;
-const CODE_START_Y = 35;
+const CODE_START_Y = 20;
 const CODE_LINE_HEIGHT = 14;
 
 const CODE_HIGHLIGHT_COLOR = '#FF0000';
@@ -46,7 +46,7 @@ const LCS_CELL_COLOR = '#99CCFF';
 const MAX_SEQUENCE_LENGTH = 13;
 
 const SEQUENCE_START_X = 20;
-const SEQUENCE_START_Y = 195;
+const SEQUENCE_START_Y = 450;
 const SEQUENCE_DELTA_X = 10;
 
 export default class LCS extends Algorithm {
@@ -90,19 +90,38 @@ export default class LCS extends Algorithm {
 		this.cmd(act.createLabel, this.infoLabelID, '', INFO_MSG_X, INFO_MSG_Y, 0);
 
 		this.code = [
-			['def ', 'LCS(S1, S2, matrix)', ':'],
-			['     for x from 0 to S1.length - 1:'],
-			['          for y from 0 to S2.length - 1:'],
-			['               if ', '(S1[x] == S2[y]):'],
-			['                    matrix[x][y] = 1 + ', 'matrix[x - 1][y-1]'],
-			['               else:'],
+			['procedure ', 'LCS(S1, S2, matrix)'],
+			['     matrix <- create new 2D array of length S1.length by S2.length'],
+			['     for y <- 1, to S1.length, loop'],
+			['          for x <- 1 to S2.length, loop'],
+			['               if ', '(S1[y] == S2[x])'],
+			['                    matrix[y][x] = 1 + ', 'matrix[y - 1][x - 1]'],
+			['               else'],
 			[
-				'                    matrix[x][y] = max(',
-				'matrix[x - 1][y]',
+				'                    matrix[y][x] = max(',
+				'matrix[y - 1][x]',
 				',',
-				' matrix[x][y - 1]',
+				' matrix[y][x - 1]',
 				')',
 			],
+			['          end for'],
+			['     end for'],
+			['     currY <- S1.length'],
+			['     currX <- S2.length'],
+			['     list <- create new List()'],
+			['     while currY > 0 and currX > 0, loop:'],
+			[['          if '], ['matrix[currY - 1][currX] == matrix[currY][currX - 1] ']],
+			[['           and '], ['matrix[currY][currX] != matrix [currY - 1][currX - 1]']],
+			['               list.addFront(S1[currY])'],
+			['               currX--'],
+			['               currY--'],
+			['          else'],
+			[['               if '], ['matrix[currY - 1][currX] > matrix[currY][currX - 1]']],
+			['                    currX--'],
+			['               else'],
+			['                    currY--'],
+			['     end while'],
+			['end procedure']
 		];
 
 		this.codeID = Array(this.code.length);
@@ -140,8 +159,12 @@ export default class LCS extends Algorithm {
 	}
 
 	runCallback() {
-		if (this.S1Field.value !== '' && this.S2Field.value !== '') {
-			this.implementAction(this.run.bind(this), this.S1Field.value, this.S2Field.value);
+		const string1 = this.S1Field.value;
+		const string2 = this.S2Field.value;
+		if (string1 !== '' && string2 !== '') {
+			this.S1Field.value = '';
+			this.S2Field.value = '';
+			this.implementAction(this.run.bind(this), string1, string2);
 		}
 	}
 
@@ -170,7 +193,8 @@ export default class LCS extends Algorithm {
 				this.cmd(act.setHighlight, this.tableID[i + 1][j + 1], 1);
 				this.cmd(act.setHighlight, this.S1TableID[i], 1);
 				this.cmd(act.setHighlight, this.S2TableID[j], 1);
-				this.cmd(act.setForegroundColor, this.codeID[3][1], CODE_HIGHLIGHT_COLOR);
+				this.highlight(4, 1);
+				// this.cmd(act.setForegroundColor, this.codeID[4][1], CODE_HIGHLIGHT_COLOR);
 				this.cmd(
 					act.setText,
 					this.infoLabelID,
@@ -179,10 +203,13 @@ export default class LCS extends Algorithm {
 				this.cmd(act.step);
 				this.cmd(act.setHighlight, this.S1TableID[i], 0);
 				this.cmd(act.setHighlight, this.S2TableID[j], 0);
-				this.cmd(act.setForegroundColor, this.codeID[3][1], CODE_STANDARD_COLOR);
+				this.unhighlight(4, 1);
+				// this.cmd(act.setForegroundColor, this.codeID[4][1], CODE_STANDARD_COLOR);
 				if (str1.charAt(i) === str2.charAt(j)) {
-					this.cmd(act.setForegroundColor, this.codeID[4][0], CODE_HIGHLIGHT_COLOR);
-					this.cmd(act.setForegroundColor, this.codeID[4][1], CODE_HIGHLIGHT_COLOR);
+					// this.cmd(act.setForegroundColor, this.codeID[5][0], CODE_HIGHLIGHT_COLOR);
+					// this.cmd(act.setForegroundColor, this.codeID[5][1], CODE_HIGHLIGHT_COLOR);
+					this.highlight(5, 0);
+					this.highlight(5, 1);
 					this.cmd(act.setHighlight, this.tableID[i + 1 - 1][j + 1 - 1], 1);
 					this.cmd(act.setText, this.infoLabelID, 'Match, increment from the diagonal');
 					this.cmd(act.step);
@@ -202,17 +229,17 @@ export default class LCS extends Algorithm {
 					);
 					this.cmd(act.step);
 					this.cmd(act.delete, moveID);
-					this.cmd(act.setForegroundColor, this.codeID[4][0], CODE_STANDARD_COLOR);
-					this.cmd(act.setForegroundColor, this.codeID[4][1], CODE_STANDARD_COLOR);
+					this.unhighlight(5, 0);
+					this.unhighlight(5, 1);
 					this.cmd(act.setHighlight, this.tableID[i + 1 - 1][j + 1 - 1], 0);
 					this.tableVals[i + 1][j + 1] = this.tableVals[i][j] + 1;
 					this.cmd(act.setText, this.tableID[i + 1][j + 1], this.tableVals[i + 1][j + 1]);
 				} else {
-					this.cmd(act.setForegroundColor, this.codeID[6][0], CODE_HIGHLIGHT_COLOR);
-					this.cmd(act.setForegroundColor, this.codeID[6][1], CODE_HIGHLIGHT_COLOR);
-					this.cmd(act.setForegroundColor, this.codeID[6][2], CODE_HIGHLIGHT_COLOR);
-					this.cmd(act.setForegroundColor, this.codeID[6][3], CODE_HIGHLIGHT_COLOR);
-					this.cmd(act.setForegroundColor, this.codeID[6][4], CODE_HIGHLIGHT_COLOR);
+					this.highlight(7, 0);
+					this.highlight(7, 1);
+					this.highlight(7, 2);
+					this.highlight(7, 3);
+					this.highlight(7, 4);
 					this.cmd(act.setHighlight, this.tableID[i][j + 1], 1);
 					this.cmd(act.setHighlight, this.tableID[i + 1][j], 1);
 					this.cmd(
@@ -222,14 +249,14 @@ export default class LCS extends Algorithm {
 					);
 					this.cmd(act.step);
 
-					this.cmd(act.setForegroundColor, this.codeID[6][0], CODE_STANDARD_COLOR);
-					this.cmd(act.setForegroundColor, this.codeID[6][2], CODE_STANDARD_COLOR);
-					this.cmd(act.setForegroundColor, this.codeID[6][4], CODE_STANDARD_COLOR);
-
+					this.unhighlight(7, 0);
+					this.unhighlight(7, 2);
+					this.unhighlight(7, 4);
+				
 					if (this.tableVals[i][j + 1] > this.tableVals[i + 1][j]) {
 						this.cmd(act.setHighlight, this.tableID[i + 1][j], 0);
-						this.cmd(act.setForegroundColor, this.codeID[6][3], CODE_STANDARD_COLOR);
-
+						this.unhighlight(7, 3);
+						
 						this.tableVals[i + 1][j + 1] = this.tableVals[i][j + 1];
 						this.cmd(
 							act.createLabel,
@@ -239,7 +266,7 @@ export default class LCS extends Algorithm {
 							this.tableYPos[i][j + 1],
 						);
 					} else {
-						this.cmd(act.setForegroundColor, this.codeID[6][1], CODE_STANDARD_COLOR);
+						this.unhighlight(7, 1);
 						this.cmd(act.setHighlight, this.tableID[i][j + 1], 0);
 						this.tableVals[i + 1][j + 1] = this.tableVals[i + 1][j];
 						this.cmd(
@@ -261,10 +288,10 @@ export default class LCS extends Algorithm {
 					this.cmd(act.setText, this.tableID[i + 1][j + 1], this.tableVals[i + 1][j + 1]);
 					this.cmd(act.delete, moveID);
 					if (this.tableVals[i][j + 1] > this.tableVals[i + 1][j]) {
-						this.cmd(act.setForegroundColor, this.codeID[6][1], CODE_STANDARD_COLOR);
+						this.unhighlight(7, 1);
 						this.cmd(act.setHighlight, this.tableID[i][j + 1], 0);
 					} else {
-						this.cmd(act.setForegroundColor, this.codeID[6][3], CODE_STANDARD_COLOR);
+						this.unhighlight(7, 3);
 						this.cmd(act.setHighlight, this.tableID[i + 1][j], 0);
 					}
 				}
@@ -272,12 +299,22 @@ export default class LCS extends Algorithm {
 			}
 		}
 
+		this.highlight(9, 0);
+		this.highlight(10, 0);
+		this.highlight(11, 0);
+		this.highlight(12, 0);
+
 		this.cmd(act.setText, this.infoLabelID, 'Finished building table, can now find LCS');
 		this.cmd(act.step);
 
 		this.buildLCSFromTable(str1, str2);
 
+		this.unhighlight(24, 0);
+		this.highlight(25, 0);
 		this.cmd(act.setText, this.infoLabelID, 'Done');
+		this.cmd(act.step);
+		this.unhighlight(25, 0);
+
 		return this.commands;
 	}
 
@@ -408,10 +445,42 @@ export default class LCS extends Algorithm {
 				}
 			}
 		}
+		this.cmd(act.step);
+		this.unhighlight(9, 0);
+		this.unhighlight(10, 0);
+		this.unhighlight(11, 0);
+		this.unhighlight(12, 0);
 
 		while (currX > 0 && currY > 0) {
-			this.cmd(act.setHighlight, this.tableID[currX][currY], 1);
 			this.cmd(act.setBackgroundColor, this.tableID[currX][currY], LCS_CELL_COLOR);
+			this.cmd(act.step);
+
+			this.unhighlight(14, 1);
+			this.unhighlight(15, 1);
+			for (let i = 16; i < 24; i++) {
+				this.unhighlight(i, 0);
+			}
+
+			this.highlight(14, 1);
+			this.cmd(act.setHighlight, this.tableID[currX - 1][currY], 1);
+			this.cmd(act.setHighlight, this.tableID[currX][currY - 1], 1);
+			this.cmd(act.step);
+			
+			this.unhighlight(14, 1);
+			this.cmd(act.setHighlight, this.tableID[currX - 1][currY], 0);
+			this.cmd(act.setHighlight, this.tableID[currX][currY - 1], 0);
+
+			if (this.tableVals[currX - 1][currY] === this.tableVals[currX][currY - 1]) {
+				this.highlight(15, 1);
+				this.cmd(act.setHighlight, this.tableID[currX][currY], 1);
+				this.cmd(act.setHighlight, this.tableID[currX - 1][currY - 1], 1);
+				this.cmd(act.step);
+				
+				this.unhighlight(15, 1);
+
+				this.cmd(act.setHighlight, this.tableID[currX][currY], 0);
+				this.cmd(act.setHighlight, this.tableID[currX - 1][currY - 1], 0);
+			}
 
 			if (
 				this.tableVals[currX - 1][currY] === this.tableVals[currX][currY - 1] &&
@@ -430,14 +499,23 @@ export default class LCS extends Algorithm {
 				this.cmd(act.setHighlight, this.S2TableID[currY - 1], 0);
 			} else {
 				if (this.tableVals[currX - 1][currY] > this.tableVals[currX][currY - 1]) {
+					this.highlight(20, 1);
+					this.cmd(act.setHighlight, this.tableID[currX - 1][currY], 1);
+					this.cmd(act.setHighlight, this.tableID[currX][currY - 1], 1);
+					this.cmd(act.step);
+
+					this.unhighlight(20, 1);
+					this.cmd(act.setHighlight, this.tableID[currX - 1][currY], 0);
+					this.cmd(act.setHighlight, this.tableID[currX][currY - 1], 0);
+					this.highlight(21, 0);
+
 					this.cmd(act.setText, this.infoLabelID, 'Move left');
 				} else {
+					this.highlight(23, 0);
+
 					this.cmd(act.setText, this.infoLabelID, 'Move up');
 				}
-				this.cmd(act.step);
 			}
-
-			this.cmd(act.setHighlight, this.tableID[currX][currY], 0);
 
 			if (
 				this.tableVals[currX - 1][currY] === this.tableVals[currX][currY - 1] &&
@@ -464,16 +542,35 @@ export default class LCS extends Algorithm {
 					);
 				}
 
+				this.highlight(16, 0);
+				this.highlight(17, 0);
+				this.highlight(18, 0);
+
 				currX = currX - 1;
 				currY = currY - 1;
 			} else {
 				if (this.tableVals[currX - 1][currY] > this.tableVals[currX][currY - 1]) {
 					currX = currX - 1;
+					this.highlight(21, 0);
 				} else {
 					currY = currY - 1;
+					this.highlight(23, 0);
 				}
 			}
 		}
+		for (let i = 16; i < 24; i++) {
+			this.unhighlight(i, 0);
+		}
+		this.highlight(24, 0);
+		this.cmd(act.step);
+	}
+
+	highlight(ind1, ind2) {
+		this.cmd(act.setForegroundColor, this.codeID[ind1][ind2], CODE_HIGHLIGHT_COLOR);
+	}
+
+	unhighlight(ind1, ind2) {
+		this.cmd(act.setForegroundColor, this.codeID[ind1][ind2], CODE_STANDARD_COLOR);
 	}
 
 	enableUI() {


### PR DESCRIPTION
Closes #144 

Updated LCS pseudocode for clarity and to include the traceback portion of the algorithm. Also changed the formatting of LCS and HeapSort to match.
Before:
![image](https://user-images.githubusercontent.com/64664063/139863498-0c06d58d-1232-45f9-9ade-479f48e71e05.png)

After:
![image](https://user-images.githubusercontent.com/64664063/139861878-9f55b744-f205-4c2b-baf5-06e19880312d.png)

Additionally, added highlighting of indices to LCS backtracing:
![image](https://user-images.githubusercontent.com/64664063/139866012-e195dbc6-3479-471d-96a6-9b79bbab18c9.png)
