### PR TITLE
Heap/PQ Resize

### DIFF
--- a/src/algo/Heap.js
+++ b/src/algo/Heap.js
@@ -34,6 +34,7 @@ import Algorithm, {
 import { act } from '../anim/AnimationMain';
 
 const MAX_SIZE = 32;
+const LENGTH = 8;
 
 const MAX_ARRAY_SIZE = 31;
 const ARRAY_ELEM_WIDTH = 40;
@@ -62,7 +63,7 @@ export default class Heap extends Algorithm {
 
 		this.addControls();
 		this.nextIndex = 0;
-		this.array_size = 8;
+		this.array_size = LENGTH;
 		this.order = 'smaller';
 		this.setup();
 	}
@@ -174,7 +175,6 @@ export default class Heap extends Algorithm {
 	}
 
 	setup() {
-		this.createArray();
 		this.swapLabel1 = this.nextIndex++;
 		this.swapLabel2 = this.nextIndex++;
 		this.swapLabel3 = this.nextIndex++;
@@ -182,6 +182,8 @@ export default class Heap extends Algorithm {
 		this.descriptLabel1 = this.nextIndex++;
 		this.descriptLabel2 = this.nextIndex++;
 		this.descriptLabel3 = this.nextIndex++;
+		this.resetIndex = this.nextIndex;
+		this.createArray();
 		this.cmd(act.createLabel, this.descriptLabel1, '', 20, 10, 0);
 		this.cmd(act.createLabel, this.descriptLabel3, '', 300, 10, 0);
 		this.animationManager.startNewAnimation(this.commands);
@@ -203,7 +205,7 @@ export default class Heap extends Algorithm {
 
 	clearCallback() {
 		this.implementAction(this.clear.bind(this));
-		this.implementAction(this.resize.bind(this), 8, false);
+		this.implementAction(this.resize.bind(this), LENGTH, false);
 	}
 
 	buildHeapCallback() {
@@ -214,6 +216,7 @@ export default class Heap extends Algorithm {
 			list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
 		) {
 			this.buildHeapField.value = '';
+			this.implementAction(this.clear.bind(this));
 			this.implementAction(this.buildHeap.bind(this), list);
 		}
 	}
@@ -247,6 +250,22 @@ export default class Heap extends Algorithm {
 
 	reset() {
 		this.currentHeapSize = 0;
+		this.array_size = LENGTH;
+
+		this.nextIndex = this.resetIndex;
+
+		this.arrayData = new Array(this.array_size);
+		this.arrayLabels = new Array(this.array_size);
+		this.arrayRects = new Array(this.array_size);
+		this.circleObjs = new Array(this.array_size);
+		this.arrayXPositions = new Array(this.array_size);
+
+		for (let i = 0; i < this.array_size; i++) {
+			this.arrayXPositions[i] = ARRAY_INITIAL_X + i * ARRAY_ELEM_WIDTH;
+			this.arrayLabels[i] = this.nextIndex++;
+			this.arrayRects[i] = this.nextIndex++;
+			this.circleObjs[i] = this.nextIndex++;
+		}
 	}
 
 	swap(index1, index2) {
@@ -408,8 +427,6 @@ export default class Heap extends Algorithm {
 	buildHeap(params) {
 		this.commands = [];
 
-		this.implementAction(this.clear.bind(this));
-
 		this.arrayData = params
 			.map(Number) // Map to numbers (to remove invalid characters)
 			.filter(x => !Number.isNaN(x)) // Remove stuff that was invalid
@@ -531,7 +548,6 @@ export default class Heap extends Algorithm {
 		}
 		this.cmd(act.setText, this.descriptLabel1, '');
 		this.cmd(act.setText, this.descriptLabel3, '');
-		console.log(this.commands);
 		return this.commands;
 	}
 
@@ -576,9 +592,6 @@ export default class Heap extends Algorithm {
 			}
 			this.newArrayData[i] = this.arrayData[i];
 		}
-
-		console.log(this.circleObjs.toString());
-		console.log(this.newCircleObjs.toString());
 
 		if (add) {
 			for (let i = 0; i < this.array_size; i++) {

--- a/src/algo/Heap.js
+++ b/src/algo/Heap.js
@@ -33,15 +33,10 @@ import Algorithm, {
 } from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
 
-<<<<<<< HEAD
 const MAX_SIZE = 32;
-const ARRAY_ELEM_WIDTH = 40;
-=======
-const MAX_ARRAY_SIZE = 31;
 
-const ARRAY_SIZE = 32;
-const ARRAY_ELEM_WIDTH = 30;
->>>>>>> master
+const MAX_ARRAY_SIZE = 31;
+const ARRAY_ELEM_WIDTH = 40;
 const ARRAY_ELEM_HEIGHT = 25;
 const ARRAY_INITIAL_X = 30;
 
@@ -68,6 +63,7 @@ export default class Heap extends Algorithm {
 		this.addControls();
 		this.nextIndex = 0;
 		this.array_size = 8;
+		this.order = 'smaller';
 		this.setup();
 	}
 
@@ -185,7 +181,9 @@ export default class Heap extends Algorithm {
 		this.swapLabel4 = this.nextIndex++;
 		this.descriptLabel1 = this.nextIndex++;
 		this.descriptLabel2 = this.nextIndex++;
+		this.descriptLabel3 = this.nextIndex++;
 		this.cmd(act.createLabel, this.descriptLabel1, '', 20, 10, 0);
+		this.cmd(act.createLabel, this.descriptLabel3, '', 300, 10, 0);
 		this.animationManager.startNewAnimation(this.commands);
 		this.animationManager.skipForward();
 		this.animationManager.clearHistory();
@@ -211,10 +209,10 @@ export default class Heap extends Algorithm {
 	buildHeapCallback() {
 		const list = this.buildHeapField.value.split(',').filter(x => x !== '');
 		if (
-			this.buildHeapField.value !== ''
-			&& list.length <= MAX_ARRAY_SIZE
-			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
-			) {
+			this.buildHeapField.value !== '' &&
+			list.length <= MAX_ARRAY_SIZE &&
+			list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+		) {
 			this.buildHeapField.value = '';
 			this.implementAction(this.buildHeap.bind(this), list);
 		}
@@ -224,6 +222,7 @@ export default class Heap extends Algorithm {
 		if (!this.isMinHeap) {
 			this.clearCallback();
 			this.isMinHeap = true;
+			this.order = 'smaller';
 		}
 	}
 
@@ -231,6 +230,7 @@ export default class Heap extends Algorithm {
 		if (this.isMinHeap) {
 			this.clearCallback();
 			this.isMinHeap = false;
+			this.order = 'larger';
 		}
 	}
 
@@ -312,6 +312,7 @@ export default class Heap extends Algorithm {
 			childIndex = 2 * index;
 
 			if (index * 2 + 1 <= this.currentHeapSize) {
+				this.cmd(act.setText, this.descriptLabel3, `Finding ${this.order} of two children`);
 				this.setIndexHighlight(2 * index, 1);
 				this.setIndexHighlight(2 * index + 1, 1);
 				this.cmd(act.step);
@@ -321,11 +322,13 @@ export default class Heap extends Algorithm {
 					childIndex = 2 * index + 1;
 				}
 			}
+			this.cmd(act.setText, this.descriptLabel3, `Comparing child to parent`);
 			this.setIndexHighlight(index, 1);
 			this.setIndexHighlight(childIndex, 1);
 			this.cmd(act.step);
 			this.setIndexHighlight(index, 0);
 			this.setIndexHighlight(childIndex, 0);
+			this.cmd(act.setText, this.descriptLabel3, ``);
 
 			if (this.downheapCompare(childIndex, index)) {
 				this.swap(childIndex, index);
@@ -507,6 +510,7 @@ export default class Heap extends Algorithm {
 		if (currentIndex > 1) {
 			this.setIndexHighlight(currentIndex, 1);
 			this.setIndexHighlight(parentIndex, 1);
+			this.cmd(act.setText, this.descriptLabel3, `Comparing child to parent`);
 			this.cmd(act.step);
 			this.setIndexHighlight(currentIndex, 0);
 			this.setIndexHighlight(parentIndex, 0);
@@ -519,12 +523,14 @@ export default class Heap extends Algorithm {
 			if (currentIndex > 1) {
 				this.setIndexHighlight(currentIndex, 1);
 				this.setIndexHighlight(parentIndex, 1);
+				this.cmd(act.setText, this.descriptLabel3, `Comparing child to parent`);
 				this.cmd(act.step);
 				this.setIndexHighlight(currentIndex, 0);
 				this.setIndexHighlight(parentIndex, 0);
 			}
 		}
 		this.cmd(act.setText, this.descriptLabel1, '');
+		this.cmd(act.setText, this.descriptLabel3, '');
 		console.log(this.commands);
 		return this.commands;
 	}
@@ -695,10 +701,10 @@ export default class Heap extends Algorithm {
 	}
 
 	disableUI() {
-		this.controls.forEach(button => button.disabled = true);
+		this.controls.forEach(button => (button.disabled = true));
 	}
 
 	enableUI() {
-		this.controls.forEach(button => button.disabled = false);
+		this.controls.forEach(button => (button.disabled = false));
 	}
 }


### PR DESCRIPTION
closes #129 

Heap can resize now!

The initial array is length 8, and doubles each time a resize is necessary (up to length 32, the original max length).
<img width="650" alt="image" src="https://user-images.githubusercontent.com/67525591/142877822-90b4cc56-d4c6-4626-aa78-b6c920e48341.png">
<img width="650" alt="image" src="https://user-images.githubusercontent.com/67525591/142879287-2716e672-7a19-4b07-a3c4-b584158ed3d3.png">


Buildheap also implements this change, with the backing array initialized to 2*n (unless n >= 16).

Also, on clear the array is reset to its initial capacity. This felt a little more consistent with how we implement clear() on homework.