### PR TITLE
Pseudocode highlighting for BST Depth First Traversals

### DIFF
--- a/src/algo/BST.js
+++ b/src/algo/BST.js
@@ -213,14 +213,7 @@ export default class BST extends Algorithm {
 	}
 
 
-	// [
-	// 0	['procedure preOrder(Node node)'],
-	// 1    ['     if node is not null:'],
-	// 2	['          look at data in the node'],
-	// 3	['          recurse left'],
-	// 4	['          recurse right'],
-	// 5	['end procedure']
-	// ]
+
 	preOrderRec(tree, passedCodeID) {
 		this.codeID = passedCodeID;
 		this.cmd(act.step);
@@ -266,9 +259,7 @@ export default class BST extends Algorithm {
 		return;
 	}
 
-	levelOrder(tree, passedCodeID) {
-		this.codeID = passedCodeID;
-		this.highlight(1,0);
+	levelOrder(tree) {
 
 		this.highlightID = this.nextIndex++;
 		// const firstLabel = this.nextIndex;
@@ -325,20 +316,7 @@ export default class BST extends Algorithm {
 		}
 
 		if (this.traversal === 'level') {
-			this.codeID = this.setUpPseudocode(
-				[
-					['procedure levelOrder()'],
-					['     create Queue q'],
-					['     add root to q'],
-					['     while q is not empty:'],
-					['          Node curr = q.dequeue()'],
-					['          if curr is not null:'],
-					['               q.enequeue(curr.left)'],
-					['               q.enequeue(curr.right)'],
-					['end procedure']
-				]
-			);
-			this.levelOrder(this.treeRoot, this.codeID);
+			this.levelOrder(this.treeRoot);
 		}
 
 		this.highlightID = this.nextIndex++;
@@ -401,14 +379,6 @@ export default class BST extends Algorithm {
 	}
 
 
-	// [
-	// 0	['procedure preOrder(Node node)'],
-	// 1    ['     if node is not null:'],
-	// 2	['          recurse left'],
-	// 3	['          recurse right'],
-	// 4	['          look at data in the node'],
-	// 5	['end procedure']
-	// ]
 	postOrderRec(tree, passedCodeID) {
 		this.codeID = passedCodeID;
 		this.cmd(act.step);
@@ -451,18 +421,22 @@ export default class BST extends Algorithm {
 	}
 
 	printTreeRec(tree, passedCodeID) {
-
 		this.codeID = passedCodeID;
-		this.highlight(1,0);
-
 		
 		this.cmd(act.step);
 		if (tree.left != null) {
+			this.unhighlight(3, 0);
+			this.unhighlight(4, 0);
+			this.highlight(2, 0);
 			this.cmd(act.move, this.highlightID, tree.left.x, tree.left.y);
 			this.printTreeRec(tree.left, passedCodeID);
 			this.cmd(act.move, this.highlightID, tree.x, tree.y);
 			this.cmd(act.step);
 		}
+		this.unhighlight(2,0);
+
+		this.unhighlight(4,0);
+		this.highlight(3,0);
 		const nextLabelID = this.nextIndex++;
 		this.cmd(act.createLabel, nextLabelID, tree.data, tree.x, tree.y);
 		this.cmd(act.setForegroundColor, nextLabelID, BST.PRINT_COLOR);
@@ -474,12 +448,19 @@ export default class BST extends Algorithm {
 			this.xPosOfNextLabel = BST.FIRST_PRINT_POS_X;
 			this.yPosOfNextLabel += BST.PRINT_VERTICAL_GAP;
 		}
+		this.unhighlight(3,0);
+
 		if (tree.right != null) {
+			this.unhighlight(2, 0);
+			this.unhighlight(3, 0);
+			this.highlight(4, 0);
 			this.cmd(act.move, this.highlightID, tree.right.x, tree.right.y);
 			this.printTreeRec(tree.right, passedCodeID);
 			this.cmd(act.move, this.highlightID, tree.x, tree.y);
 			this.cmd(act.step);
 		}
+		this.unhighlight(4,0);
+
 		return;
 	}
 

--- a/src/algo/BST.js
+++ b/src/algo/BST.js
@@ -31,6 +31,12 @@ import Algorithm, {
 } from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
 
+const CODE_START_X = 25;
+const CODE_START_Y = 35;
+const CODE_LINE_HEIGHT = 14;
+const CODE_HIGHLIGHT_COLOR = '#FF0000';
+const CODE_STANDARD_COLOR = '#000000';
+
 export default class BST extends Algorithm {
 	constructor(am, w, h) {
 		super(am, w, h);
@@ -206,10 +212,25 @@ export default class BST extends Algorithm {
 		return this.commands;
 	}
 
-	preOrderRec(tree) {
+
+	// [
+	// 0	['procedure preOrder(Node node)'],
+	// 1    ['     if node is not null:'],
+	// 2	['          look at data in the node'],
+	// 3	['          recurse left'],
+	// 4	['          recurse right'],
+	// 5	['end procedure']
+	// ]
+	preOrderRec(tree, passedCodeID) {
+		this.codeID = passedCodeID;
 		this.cmd(act.step);
 
 		const nextLabelID = this.nextIndex++;
+
+		this.unhighlight(3,0)
+		this.unhighlight(4,0)
+		this.highlight(2,0);
+
 		this.cmd(act.createLabel, nextLabelID, tree.data, tree.x, tree.y);
 		this.cmd(act.setForegroundColor, nextLabelID, BST.PRINT_COLOR);
 		this.cmd(act.move, nextLabelID, this.xPosOfNextLabel, this.yPosOfNextLabel);
@@ -220,24 +241,35 @@ export default class BST extends Algorithm {
 			this.xPosOfNextLabel = BST.FIRST_PRINT_POS_X;
 			this.yPosOfNextLabel += BST.PRINT_VERTICAL_GAP;
 		}
+		this.unhighlight(2,0);
 
 		if (tree.left != null) {
+			this.highlight(3,0);
 			this.cmd(act.move, this.highlightID, tree.left.x, tree.left.y);
-			this.preOrderRec(tree.left);
+			this.preOrderRec(tree.left, passedCodeID);
+			
 			this.cmd(act.move, this.highlightID, tree.x, tree.y);
 			this.cmd(act.step);
 		}
+		this.unhighlight(3,0);
 
 		if (tree.right != null) {
+			this.highlight(4,0);
 			this.cmd(act.move, this.highlightID, tree.right.x, tree.right.y);
-			this.preOrderRec(tree.right);
+			this.preOrderRec(tree.right, passedCodeID);
 			this.cmd(act.move, this.highlightID, tree.x, tree.y);
 			this.cmd(act.step);
 		}
+		this.unhighlight(4,0);
+
+
 		return;
 	}
 
-	levelOrder(tree) {
+	levelOrder(tree, passedCodeID) {
+		this.codeID = passedCodeID;
+		this.highlight(1,0);
+
 		this.highlightID = this.nextIndex++;
 		// const firstLabel = this.nextIndex;
 		this.cmd(
@@ -293,7 +325,20 @@ export default class BST extends Algorithm {
 		}
 
 		if (this.traversal === 'level') {
-			this.levelOrder(this.treeRoot);
+			this.codeID = this.setUpPseudocode(
+				[
+					['procedure levelOrder()'],
+					['     create Queue q'],
+					['     add root to q'],
+					['     while q is not empty:'],
+					['          Node curr = q.dequeue()'],
+					['          if curr is not null:'],
+					['               q.enequeue(curr.left)'],
+					['               q.enequeue(curr.right)'],
+					['end procedure']
+				]
+			);
+			this.levelOrder(this.treeRoot, this.codeID);
 		}
 
 		this.highlightID = this.nextIndex++;
@@ -309,11 +354,41 @@ export default class BST extends Algorithm {
 		this.yPosOfNextLabel = this.first_print_pos_y;
 
 		if (this.traversal === 'pre') {
-			this.preOrderRec(this.treeRoot);
+			this.codeID = this.setUpPseudocode(
+				[
+					['procedure preOrder(Node node)'],
+					['     if node is not null:'],
+					['          look at data in the node'],
+					['          recurse left'],
+					['          recurse right'],
+					['end procedure']
+				]
+			);
+			this.preOrderRec(this.treeRoot, this.codeID);
 		} else if (this.traversal === 'in') {
-			this.printTreeRec(this.treeRoot);
+			this.codeID = this.setUpPseudocode(
+				[
+					['procedure inOrder(Node node)'],
+					['     if node is not null:'],
+					['          recurse left'],
+					['          look at data in the node'],
+					['          recurse right'],
+					['end procedure']
+				]
+			);
+			this.printTreeRec(this.treeRoot, this.codeID);
 		} else if (this.traversal === 'post') {
-			this.postOrderRec(this.treeRoot);
+			this.codeID = this.setUpPseudocode(
+				[
+					['procedure postOrder(Node node)'],
+					['     if node is not null:'],
+					['          recurse left'],
+					['          recurse right'],
+					['          look at data in the node'],
+					['end procedure']
+				]
+			);
+			this.postOrderRec(this.treeRoot, this.codeID);
 		}
 
 		this.cmd(act.delete, this.highlightID);
@@ -325,22 +400,40 @@ export default class BST extends Algorithm {
 		return this.commands;
 	}
 
-	postOrderRec(tree) {
+
+	// [
+	// 0	['procedure preOrder(Node node)'],
+	// 1    ['     if node is not null:'],
+	// 2	['          recurse left'],
+	// 3	['          recurse right'],
+	// 4	['          look at data in the node'],
+	// 5	['end procedure']
+	// ]
+	postOrderRec(tree, passedCodeID) {
+		this.codeID = passedCodeID;
 		this.cmd(act.step);
 		if (tree.left != null) {
+			this.unhighlight(3,0)
+			this.highlight(2,0)
 			this.cmd(act.move, this.highlightID, tree.left.x, tree.left.y);
-			this.postOrderRec(tree.left);
+			this.postOrderRec(tree.left, passedCodeID);
 			this.cmd(act.move, this.highlightID, tree.x, tree.y);
 			this.cmd(act.step);
 		}
+		this.unhighlight(2,0)
+
 
 		if (tree.right != null) {
+			this.unhighlight(2,0)
+			this.highlight(3,0)
 			this.cmd(act.move, this.highlightID, tree.right.x, tree.right.y);
-			this.postOrderRec(tree.right);
+			this.postOrderRec(tree.right, passedCodeID);
 			this.cmd(act.move, this.highlightID, tree.x, tree.y);
 			this.cmd(act.step);
 		}
+		this.unhighlight(3,0)
 
+		this.highlight(4,0)
 		const nextLabelID = this.nextIndex++;
 		this.cmd(act.createLabel, nextLabelID, tree.data, tree.x, tree.y);
 		this.cmd(act.setForegroundColor, nextLabelID, BST.PRINT_COLOR);
@@ -352,14 +445,21 @@ export default class BST extends Algorithm {
 			this.xPosOfNextLabel = BST.FIRST_PRINT_POS_X;
 			this.yPosOfNextLabel += BST.PRINT_VERTICAL_GAP;
 		}
+		this.unhighlight(4,0)
+
 		return;
 	}
 
-	printTreeRec(tree) {
+	printTreeRec(tree, passedCodeID) {
+
+		this.codeID = passedCodeID;
+		this.highlight(1,0);
+
+		
 		this.cmd(act.step);
 		if (tree.left != null) {
 			this.cmd(act.move, this.highlightID, tree.left.x, tree.left.y);
-			this.printTreeRec(tree.left);
+			this.printTreeRec(tree.left, passedCodeID);
 			this.cmd(act.move, this.highlightID, tree.x, tree.y);
 			this.cmd(act.step);
 		}
@@ -376,7 +476,7 @@ export default class BST extends Algorithm {
 		}
 		if (tree.right != null) {
 			this.cmd(act.move, this.highlightID, tree.right.x, tree.right.y);
-			this.printTreeRec(tree.right);
+			this.printTreeRec(tree.right, passedCodeID);
 			this.cmd(act.move, this.highlightID, tree.x, tree.y);
 			this.cmd(act.step);
 		}
@@ -760,6 +860,43 @@ export default class BST extends Algorithm {
 		for (let i = 0; i < this.controls.length; i++) {
 			this.controls[i].disabled = false;
 		}
+	}
+
+
+	setUpPseudocode(tailoredCode) {
+		this.code = tailoredCode;
+
+		this.codeID = Array(this.code.length);
+		let i, j;
+		for (i = 0; i < this.code.length; i++) {
+			this.codeID[i] = new Array(this.code[i].length);
+			for (j = 0; j < this.code[i].length; j++) {
+				this.codeID[i][j] = this.nextIndex++;
+				this.cmd(
+					act.createLabel,
+					this.codeID[i][j],
+					this.code[i][j],
+					CODE_START_X,
+					CODE_START_Y + i * CODE_LINE_HEIGHT,
+					0,
+				);
+				this.cmd(act.setForegroundColor, this.codeID[i][j], CODE_STANDARD_COLOR);
+				if (j > 0) {
+					this.cmd(act.alignRight, this.codeID[i][j], this.codeID[i][j - 1]);
+				}
+			}
+		}
+
+		return this.codeID;
+
+	}
+
+	highlight(ind1, ind2) {
+		this.cmd(act.setForegroundColor, this.codeID[ind1][ind2], CODE_HIGHLIGHT_COLOR);
+	}
+
+	unhighlight(ind1, ind2) {
+		this.cmd(act.setForegroundColor, this.codeID[ind1][ind2], CODE_STANDARD_COLOR);
 	}
 }
 


### PR DESCRIPTION
- Implements pseudocode highlighting for depth-first traversals. The pseudocode for these are the recursive implementations and are from the course modules on canvas. 
- Added a helper function called `setUpPseudocode(tailoredCode) ` in BST.js that parses an array of pseudocode & renders it in addition to generating the codeID array (for highlighting & unhighlighting). Later down the line, should prob refactor this and make it a module to import into the algo files to avoid repetitive code.
    - Because of this, added an extra parameter to each traversal algo called 'passedCodeID' to avoid re-rendering the pseudocode on top of itself on the page during every recursive call.

- This PR excludes the pseudocode highlighting functionality for level order traversals. This is because we don't have a visual component displaying a queue for the level order traversal for BST's. Because of this, even if we did the highlighting for level order, it would highlight and unhighlight so quickly that it's not visible to the user. In addition, without the queue visual component, there's no point in highlighting lines of the pseudocode of the level order traversal that is directly related to the queue (enqueueing left & right children, dequeuing from the queue). 
- Addresses (only partially of course) #127 