### PR TITLE
Fix Handling of SkipList Duplicates

### DIFF
--- a/src/algo/SkipList.js
+++ b/src/algo/SkipList.js
@@ -48,6 +48,9 @@ const CF_LABEL_Y = 37;
 const CF_STRING_X = 120;
 const CF_STRING_Y = 37;
 
+const EXP_LABEL_X = 250;
+const EXP_LABEL_Y = 30
+
 const NINF = '\u2212\u221E'; // Negative infinity
 const PINF = '\u221E'; // Positive infinity
 
@@ -101,7 +104,7 @@ export default class SkipList extends Algorithm {
 		);
 		this.controls.push(this.headsField);
 
-		addLabelToAlgorithmBar('heads', topHorizontalGroup);
+		addLabelToAlgorithmBar('heads (Max 4)', topHorizontalGroup);
 
 		// Add with heads button
 		this.addWithHeadsButton = addControlToAlgorithmBar('Button', 'Add', bottomHorizontalGroup);
@@ -278,6 +281,7 @@ export default class SkipList extends Algorithm {
 
 		const cfLabelId = this.nextIndex++;
 		const cfStringId = this.nextIndex++;
+		const expLabelID = this.nextIndex++;
 
 		let headsString = '';
 		for (let i = 0; i < heads; i++) {
@@ -289,6 +293,7 @@ export default class SkipList extends Algorithm {
 		this.cmd(act.createLabel, valueStringId, value, VALUE_STRING_X, VALUE_STRING_Y);
 		this.cmd(act.createLabel, cfLabelId, 'Coin Flipper:', CF_LABEL_X, CF_LABEL_Y);
 		this.cmd(act.createLabel, cfStringId, headsString, CF_STRING_X, CF_STRING_Y);
+		this.cmd(act.createLabel, expLabelID, '', EXP_LABEL_X, EXP_LABEL_Y);
 		this.cmd(act.step);
 
 		// Add levels
@@ -338,13 +343,16 @@ export default class SkipList extends Algorithm {
 			newCol++;
 		}
 
-		// Move IDs and data in next columns to the right
-		for (let col = this.nodeID.length - 1; col >= newCol; col--) {
-			this.nodeID[col + 1] = this.nodeID[col];
-			this.data[col + 1] = this.data[col];
-		}
-		this.nodeID[newCol] = [];
-		this.data[newCol] = [];
+		//this step should be skipped in the case of a duplicate
+		if (value !== this.data[newCol][0]) {
+			// Move IDs and data in next columns to the right
+			for (let col = this.nodeID.length - 1; col >= newCol; col--) {
+				this.nodeID[col + 1] = this.nodeID[col];
+				this.data[col + 1] = this.data[col];
+			}
+			this.nodeID[newCol] = [];
+			this.data[newCol] = [];
+	}
 
 		// Traverse and add
 		let col = 0;
@@ -366,6 +374,7 @@ export default class SkipList extends Algorithm {
 			// Move right until next element is greater or equal
 			let nextCol = this.getNextCol(col, row);
 			if (value === this.data[nextCol][row]) {
+				col = nextCol;
 				foundDuplicate = true;
 				break;
 			}
@@ -379,6 +388,12 @@ export default class SkipList extends Algorithm {
 				this.cmd(act.step);
 				col = nextCol;
 				nextCol = this.getNextCol(col, row);
+			}
+
+			if (value === this.data[nextCol][row]) {
+				col = nextCol;
+				foundDuplicate = true;
+				break;
 			}
 
 			// Move highlight circle downward
@@ -397,12 +412,25 @@ export default class SkipList extends Algorithm {
 		// Add nodes bottom-up to the new column if no duplicate has been found
 		if (!foundDuplicate) {
 			this.shiftColumns(newCol);
-			row++;
+			} else {
+			this.cmd(
+					act.move,
+					highlightID,
+					SKIP_LIST_START_X + SKIP_LIST_SPACING * col,
+					SKIP_LIST_START_Y - SKIP_LIST_SPACING * row,
+				);
+				this.cmd(act.step);
+			this.cmd(act.setText, expLabelID, 'Duplicate found!');
+			this.cmd(act.step);
+		}
+		row++;
 			// Having a highlight circle in the previous ID causes an object to look weird (this
 			// seems to be an already existing bug) Creating a random object before it is a workaround
 			this.cmd(act.createCircle, this.nextIndex++, '', -100, -100, 0);
 
 			while (row <= heads) {
+				this.cmd(act.setText, expLabelID, 'Adding data');
+				this.cmd(act.step);
 				this.data[newCol][row] = value;
 				this.nodeID[newCol][row] = this.nextIndex++;
 				this.cmd(
@@ -448,13 +476,13 @@ export default class SkipList extends Algorithm {
 				this.cmd(act.step);
 				row++;
 			}
-		}
 
 		this.cmd(act.delete, valueLabelId);
 		this.cmd(act.delete, valueStringId);
 		this.cmd(act.delete, cfLabelId);
 		this.cmd(act.delete, cfStringId);
 		this.cmd(act.delete, highlightID);
+		this.cmd(act.delete, expLabelID);
 
 		this.size++;
 

--- a/src/algo/SkipList.js
+++ b/src/algo/SkipList.js
@@ -49,7 +49,7 @@ const CF_STRING_X = 120;
 const CF_STRING_Y = 37;
 
 const EXP_LABEL_X = 250;
-const EXP_LABEL_Y = 30
+const EXP_LABEL_Y = 30;
 
 const NINF = '\u2212\u221E'; // Negative infinity
 const PINF = '\u221E'; // Positive infinity
@@ -352,7 +352,7 @@ export default class SkipList extends Algorithm {
 			}
 			this.nodeID[newCol] = [];
 			this.data[newCol] = [];
-	}
+		}
 
 		// Traverse and add
 		let col = 0;
@@ -412,70 +412,60 @@ export default class SkipList extends Algorithm {
 		// Add nodes bottom-up to the new column if no duplicate has been found
 		if (!foundDuplicate) {
 			this.shiftColumns(newCol);
-			} else {
+		} else {
 			this.cmd(
-					act.move,
-					highlightID,
-					SKIP_LIST_START_X + SKIP_LIST_SPACING * col,
-					SKIP_LIST_START_Y - SKIP_LIST_SPACING * row,
-				);
-				this.cmd(act.step);
+				act.move,
+				highlightID,
+				SKIP_LIST_START_X + SKIP_LIST_SPACING * col,
+				SKIP_LIST_START_Y - SKIP_LIST_SPACING * row,
+			);
+			this.cmd(act.step);
 			this.cmd(act.setText, expLabelID, 'Duplicate found!');
 			this.cmd(act.step);
 		}
 		row++;
-			// Having a highlight circle in the previous ID causes an object to look weird (this
-			// seems to be an already existing bug) Creating a random object before it is a workaround
-			this.cmd(act.createCircle, this.nextIndex++, '', -100, -100, 0);
+		// Having a highlight circle in the previous ID causes an object to look weird (this
+		// seems to be an already existing bug) Creating a random object before it is a workaround
+		this.cmd(act.createCircle, this.nextIndex++, '', -100, -100, 0);
 
-			while (row <= heads) {
-				this.cmd(act.setText, expLabelID, 'Adding data');
-				this.cmd(act.step);
-				this.data[newCol][row] = value;
-				this.nodeID[newCol][row] = this.nextIndex++;
-				this.cmd(
-					act.createSkipListNode,
-					this.nodeID[newCol][row],
-					value,
-					SKIP_LIST_ELEM_SIZE,
-					SKIP_LIST_ELEM_SIZE,
-					SKIP_LIST_START_X + SKIP_LIST_SPACING * newCol,
-					SKIP_LIST_START_Y - SKIP_LIST_SPACING * row,
-				);
-				const prevCol = this.getPrevCol(newCol, row);
-				const nextCol = this.getNextCol(newCol, row);
-				this.cmd(act.disconnect, this.nodeID[prevCol][row], this.nodeID[nextCol][row]);
+		while (row <= heads) {
+			this.cmd(act.setText, expLabelID, 'Adding data');
+			this.cmd(act.step);
+			this.data[newCol][row] = value;
+			this.nodeID[newCol][row] = this.nextIndex++;
+			this.cmd(
+				act.createSkipListNode,
+				this.nodeID[newCol][row],
+				value,
+				SKIP_LIST_ELEM_SIZE,
+				SKIP_LIST_ELEM_SIZE,
+				SKIP_LIST_START_X + SKIP_LIST_SPACING * newCol,
+				SKIP_LIST_START_Y - SKIP_LIST_SPACING * row,
+			);
+			const prevCol = this.getPrevCol(newCol, row);
+			const nextCol = this.getNextCol(newCol, row);
+			this.cmd(act.disconnect, this.nodeID[prevCol][row], this.nodeID[nextCol][row]);
+			this.cmd(act.connectSkipList, this.nodeID[prevCol][row], this.nodeID[newCol][row], 3);
+			this.cmd(act.connectSkipList, this.nodeID[newCol][row], this.nodeID[nextCol][row], 3);
+			if (row !== 0) {
 				this.cmd(
 					act.connectSkipList,
-					this.nodeID[prevCol][row],
+					this.nodeID[newCol][row - 1],
 					this.nodeID[newCol][row],
-					3,
+					0,
 				);
-				this.cmd(
-					act.connectSkipList,
-					this.nodeID[newCol][row],
-					this.nodeID[nextCol][row],
-					3,
-				);
-				if (row !== 0) {
-					this.cmd(
-						act.connectSkipList,
-						this.nodeID[newCol][row - 1],
-						this.nodeID[newCol][row],
-						0,
-					);
-				}
-				this.cmd(act.step);
-
-				this.cmd(
-					act.move,
-					highlightID,
-					SKIP_LIST_START_X + SKIP_LIST_SPACING * newCol,
-					SKIP_LIST_START_Y - SKIP_LIST_SPACING * row,
-				);
-				this.cmd(act.step);
-				row++;
 			}
+			this.cmd(act.step);
+
+			this.cmd(
+				act.move,
+				highlightID,
+				SKIP_LIST_START_X + SKIP_LIST_SPACING * newCol,
+				SKIP_LIST_START_Y - SKIP_LIST_SPACING * row,
+			);
+			this.cmd(act.step);
+			row++;
+		}
 
 		this.cmd(act.delete, valueLabelId);
 		this.cmd(act.delete, valueStringId);


### PR DESCRIPTION
closes #48 and #121 

- Fixes the issue where some layers looked lopsided after a duplicate addition
- Addresses the discussion on #48, so when a duplicate is added with more heads than the previous value those new layers are filled in