### PR TITLE
2-4 Tree Predecessor/Successor

### DIFF
--- a/src/algo/BTree.js
+++ b/src/algo/BTree.js
@@ -167,13 +167,6 @@ export default class BTree extends Algorithm {
 		this.predButton = predSuccButtonList[0];
 		this.succButton = predSuccButtonList[1];
 
-		/*
-		When the replacement strategy changes, the tree is reset.
-		I kinda wanted to maintain the tree when you change it, but 
-		it causes a bug with skipBack. If you perform a removal with
-		pred, change to succ and undo the removal, some references get
-		mixed up and deleted.
-		*/
 		this.predButton.onclick = this.predCallback.bind(this);
 		this.succButton.onclick = this.succCallback.bind(this);
 		this.succButton.checked = true;
@@ -216,14 +209,14 @@ export default class BTree extends Algorithm {
 	predCallback() {
 		if (this.predSucc !== 'pred') {
 			this.predSucc = 'pred';
-			this.commands = this.clearCallback();
+			//this.commands = this.clearCallback();  maybe this isn't necessary?
 		}
 	}
 
 	succCallback() {
 		if (this.predSucc !== 'succ') {
 			this.predSucc = 'succ';
-			this.commands = this.clearCallback();
+			//this.commands = this.clearCallback();
 		}
 	}
 
@@ -1122,8 +1115,6 @@ export default class BTree extends Algorithm {
 					this.cmd(act.setHighlight, maxNode.graphicID, 0);
 					this.cmd(act.setHighlight, tree.graphicID, 0);
 
-					this.cmd(act.setNumElements, maxNode.graphicID, maxNode.numKeys);
-
 					/* When setNumElements is called with the new #, it cuts of the last element
 					(like removeFromBack in an array). Removing the successor is more like 
 					removeFromFront so you need to shift elements left by 1*/
@@ -1133,6 +1124,7 @@ export default class BTree extends Algorithm {
 							this.cmd(act.setText, maxNode.graphicID, maxNode.keys[j], j);
 						}
 					}
+					this.cmd(act.setNumElements, maxNode.graphicID, maxNode.numKeys);
 					this.repairAfterDelete(maxNode);
 				}
 			}

--- a/src/algo/BTree.js
+++ b/src/algo/BTree.js
@@ -156,6 +156,28 @@ export default class BTree extends Algorithm {
 		this.splitThirdSelect.onclick = () => (this.split_index = 2);
 		this.splitSecondSelect.checked = true;
 		this.split_index = 1;
+
+		addDivisorToAlgorithmBar();
+
+		const predSuccButtonList = addRadioButtonGroupToAlgorithmBar(
+			['Predecessor', 'Successor'],
+			'Predecessor/Successor',
+		);
+
+		this.predButton = predSuccButtonList[0];
+		this.succButton = predSuccButtonList[1];
+
+		/*
+		When the replacement strategy changes, the tree is reset.
+		I kinda wanted to maintain the tree when you change it, but 
+		it causes a bug with skipBack. If you perform a removal with
+		pred, change to succ and undo the removal, some references get
+		mixed up and deleted.
+		*/
+		this.predButton.onclick = this.predCallback.bind(this);
+		this.succButton.onclick = this.succCallback.bind(this);
+		this.succButton.checked = true;
+		this.predSucc = 'succ';
 	}
 
 	reset() {
@@ -188,6 +210,20 @@ export default class BTree extends Algorithm {
 			this.implementAction(this.changeDegree.bind(this), newMaxDegree);
 			this.animationManager.skipForward();
 			this.animationManager.clearHistory();
+		}
+	}
+
+	predCallback() {
+		if (this.predSucc !== 'pred') {
+			this.predSucc = 'pred';
+			this.commands = this.clearCallback();
+		}
+	}
+
+	succCallback() {
+		if (this.predSucc !== 'succ') {
+			this.predSucc = 'succ';
+			this.commands = this.clearCallback();
 		}
 	}
 
@@ -1036,25 +1072,48 @@ export default class BTree extends Algorithm {
 					this.cmd(act.setHighlight, tree.graphicID, 0);
 					this.repairAfterDelete(tree);
 				} else {
-					let maxNode = tree.children[i];
-					while (!maxNode.isLeaf) {
+					let maxNode;
+					if (this.predSucc === 'pred') {
+						maxNode = tree.children[i];
+						while (!maxNode.isLeaf) {
+							this.cmd(act.setHighlight, maxNode.graphicID, 1);
+							this.cmd(act.step);
+							this.cmd(act.setHighlight, maxNode.graphicID, 0);
+							maxNode = maxNode.children[maxNode.numKeys];
+						}
 						this.cmd(act.setHighlight, maxNode.graphicID, 1);
-						this.cmd(act.step);
-						this.cmd(act.setHighlight, maxNode.graphicID, 0);
-						maxNode = maxNode.children[maxNode.numKeys];
+						tree.keys[i] = maxNode.keys[maxNode.numKeys - 1];
+						this.cmd(act.setTextColor, tree.graphicID, FOREGROUND_COLOR, i);
+						this.cmd(act.setText, tree.graphicID, '', i);
+						this.cmd(act.setText, maxNode.graphicID, '', maxNode.numKeys - 1);
+						this.cmd(
+							act.createLabel,
+							this.moveLabel1ID,
+							tree.keys[i],
+							this.getLabelX(maxNode, maxNode.numKeys - 1),
+							maxNode.y,
+						);
+					} else {
+						maxNode = tree.children[i + 1];
+						while (!maxNode.isLeaf) {
+							this.cmd(act.setHighlight, maxNode.graphicID, 1);
+							this.cmd(act.step);
+							this.cmd(act.setHighlight, maxNode.graphicID, 0);
+							maxNode = maxNode.children[0];
+						}
+						this.cmd(act.setHighlight, maxNode.graphicID, 1);
+						tree.keys[i] = maxNode.keys[0];
+						this.cmd(act.setTextColor, tree.graphicID, FOREGROUND_COLOR, i);
+						this.cmd(act.setText, tree.graphicID, '', i);
+						this.cmd(act.setText, maxNode.graphicID, '', 0);
+						this.cmd(
+							act.createLabel,
+							this.moveLabel1ID,
+							tree.keys[i],
+							this.getLabelX(maxNode, 0),
+							maxNode.y,
+						);
 					}
-					this.cmd(act.setHighlight, maxNode.graphicID, 1);
-					tree.keys[i] = maxNode.keys[maxNode.numKeys - 1];
-					this.cmd(act.setTextColor, tree.graphicID, FOREGROUND_COLOR, i);
-					this.cmd(act.setText, tree.graphicID, '', i);
-					this.cmd(act.setText, maxNode.graphicID, '', maxNode.numKeys - 1);
-					this.cmd(
-						act.createLabel,
-						this.moveLabel1ID,
-						tree.keys[i],
-						this.getLabelX(maxNode, maxNode.numKeys - 1),
-						maxNode.y,
-					);
 					this.cmd(act.move, this.moveLabel1ID, this.getLabelX(tree, i), tree.y);
 					this.cmd(act.step);
 					this.cmd(act.delete, this.moveLabel1ID);
@@ -1064,6 +1123,16 @@ export default class BTree extends Algorithm {
 					this.cmd(act.setHighlight, tree.graphicID, 0);
 
 					this.cmd(act.setNumElements, maxNode.graphicID, maxNode.numKeys);
+
+					/* When setNumElements is called with the new #, it cuts of the last element
+					(like removeFromBack in an array). Removing the successor is more like 
+					removeFromFront so you need to shift elements left by 1*/
+					if (this.predSucc === 'succ') {
+						for (let j = 0; j < maxNode.numKeys; j++) {
+							maxNode.keys[j] = maxNode.keys[j + 1];
+							this.cmd(act.setText, maxNode.graphicID, maxNode.keys[j], j);
+						}
+					}
 					this.repairAfterDelete(maxNode);
 				}
 			}


### PR DESCRIPTION
Now there's a choice between predecessor and successor when removing! 

<img width="984" alt="Screen Shot 2022-01-25 at 6 00 54 PM" src="https://user-images.githubusercontent.com/67525591/151074147-625369cf-1a84-45d5-b276-facba6504564.png">

It works in the same way as BST/AVL, but more _zesty_ because it's a 2-4 tree

closes #104