### PR TITLE
Comparison Count for Sorting Algorithms

### DIFF
--- a/src/algo/BubbleSort.js
+++ b/src/algo/BubbleSort.js
@@ -29,7 +29,7 @@ import Algorithm, {
 	addControlToAlgorithmBar,
 	addDivisorToAlgorithmBar,
 	addGroupToAlgorithmBar,
-	addLabelToAlgorithmBar
+	addLabelToAlgorithmBar,
 } from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
 
@@ -39,6 +39,9 @@ const ARRAY_START_X = 100;
 const ARRAY_START_Y = 200;
 const ARRAY_ELEM_WIDTH = 50;
 const ARRAY_ELEM_HEIGHT = 50;
+
+const COMP_COUNT_X = 100;
+const COMP_COUNT_Y = 50;
 
 let lastSwapEnabled = true;
 
@@ -55,14 +58,14 @@ export default class BubbleSort extends Algorithm {
 
 		const verticalGroup = addGroupToAlgorithmBar(false);
 
-        addLabelToAlgorithmBar(
+		addLabelToAlgorithmBar(
 			'Comma seperated list (e.g. "3,1,2"). Max 18 elements & no elements > 999',
-			verticalGroup
+			verticalGroup,
 		);
 
 		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
 
-        // List text field
+		// List text field
 		this.listField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.listField.onkeydown = this.returnSubmit(
 			this.listField,
@@ -93,13 +96,25 @@ export default class BubbleSort extends Algorithm {
 	}
 
 	setup() {
+		this.commands = [];
+
 		this.arrayData = [];
 		this.arrayID = [];
 		this.displayData = [];
 		this.iPointerID = this.nextIndex++;
 		this.jPointerID = this.nextIndex++;
 
-		this.animationManager.startNewAnimation();
+		this.comparisonCountID = this.nextIndex++;
+		this.compCount = 0;
+		this.cmd(
+			act.createLabel,
+			this.comparisonCountID,
+			'Comparison Count: ' + this.compCount,
+			COMP_COUNT_X,
+			COMP_COUNT_Y,
+		);
+
+		this.animationManager.startNewAnimation(this.commands);
 		this.animationManager.skipForward();
 		this.animationManager.clearHistory();
 	}
@@ -111,15 +126,16 @@ export default class BubbleSort extends Algorithm {
 		this.displayData = [];
 		this.iPointerID = this.nextIndex++;
 		this.jPointerID = this.nextIndex++;
+		this.compCount = 0;
 	}
 
 	sortCallback() {
 		const list = this.listField.value.split(',').filter(x => x !== '');
 		console.log(list);
 		if (
-			this.listField.value !== ''
-			&& list.length <= MAX_ARRAY_SIZE
-			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+			this.listField.value !== '' &&
+			list.length <= MAX_ARRAY_SIZE &&
+			list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
 		) {
 			this.implementAction(this.clear.bind(this));
 			this.listField.value = '';
@@ -140,6 +156,7 @@ export default class BubbleSort extends Algorithm {
 		for (let i = 0; i < this.arrayID.length; i++) {
 			this.cmd(act.delete, this.arrayID[i]);
 		}
+		this.compCount = 0;
 		this.arrayData = [];
 		this.arrayID = [];
 		this.displayData = [];
@@ -213,6 +230,11 @@ export default class BubbleSort extends Algorithm {
 			sorted = true;
 			for (let i = 0; i < end; i++) {
 				this.movePointers(i, i + 1);
+				this.cmd(
+					act.setText,
+					this.comparisonCountID,
+					'Comparison Count: ' + ++this.compCount,
+				);
 				if (this.arrayData[i] > this.arrayData[i + 1]) {
 					this.swap(i, i + 1);
 					sorted = false;

--- a/src/algo/BubbleSort.js
+++ b/src/algo/BubbleSort.js
@@ -126,6 +126,7 @@ export default class BubbleSort extends Algorithm {
 		this.displayData = [];
 		this.iPointerID = this.nextIndex++;
 		this.jPointerID = this.nextIndex++;
+		this.comparisonCountID = this.nextIndex++;
 		this.compCount = 0;
 	}
 
@@ -153,13 +154,16 @@ export default class BubbleSort extends Algorithm {
 
 	clear() {
 		this.commands = [];
+
 		for (let i = 0; i < this.arrayID.length; i++) {
 			this.cmd(act.delete, this.arrayID[i]);
 		}
-		this.compCount = 0;
+
 		this.arrayData = [];
 		this.arrayID = [];
+		this.compCount = 0;
 		this.displayData = [];
+		this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + this.compCount);
 		return this.commands;
 	}
 

--- a/src/algo/CocktailSort.js
+++ b/src/algo/CocktailSort.js
@@ -127,6 +127,7 @@ export default class CocktailSort extends Algorithm {
 		this.displayData = [];
 		this.iPointerID = this.nextIndex++;
 		this.jPointerID = this.nextIndex++;
+		this.comparisonCountID = this.nextIndex++;
 	}
 
 	sortCallback() {
@@ -151,13 +152,17 @@ export default class CocktailSort extends Algorithm {
 	}
 
 	clear() {
-		this.arrayData = [];
 		this.commands = [];
-		this.compCount = 0;
-		this.displayData = [];
+
 		for (let i = 0; i < this.arrayID.length; i++) {
 			this.cmd(act.delete, this.arrayID[i]);
 		}
+
+		this.arrayData = [];
+		this.arrayID = [];
+		this.compCount = 0;
+		this.displayData = [];
+		this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + this.compCount);
 		return this.commands;
 	}
 

--- a/src/algo/CocktailSort.js
+++ b/src/algo/CocktailSort.js
@@ -29,7 +29,7 @@ import Algorithm, {
 	addControlToAlgorithmBar,
 	addDivisorToAlgorithmBar,
 	addGroupToAlgorithmBar,
-	addLabelToAlgorithmBar
+	addLabelToAlgorithmBar,
 } from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
 
@@ -39,6 +39,9 @@ const ARRAY_START_X = 100;
 const ARRAY_START_Y = 200;
 const ARRAY_ELEM_WIDTH = 50;
 const ARRAY_ELEM_HEIGHT = 50;
+
+const COMP_COUNT_X = 100;
+const COMP_COUNT_Y = 50;
 
 let lastSwapEnabled = true;
 
@@ -55,14 +58,14 @@ export default class CocktailSort extends Algorithm {
 
 		const verticalGroup = addGroupToAlgorithmBar(false);
 
-        addLabelToAlgorithmBar(
+		addLabelToAlgorithmBar(
 			'Comma seperated list (e.g. "3,1,2"). Max 18 elements & no elements > 999',
-			verticalGroup
+			verticalGroup,
 		);
 
 		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
 
-        // List text field
+		// List text field
 		this.listField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.listField.onkeydown = this.returnSubmit(
 			this.listField,
@@ -93,19 +96,32 @@ export default class CocktailSort extends Algorithm {
 	}
 
 	setup() {
+		this.commands = [];
+
 		this.arrayData = [];
 		this.arrayID = [];
 		this.displayData = [];
 		this.iPointerID = this.nextIndex++;
 		this.jPointerID = this.nextIndex++;
 
-		this.animationManager.startNewAnimation();
+		this.comparisonCountID = this.nextIndex++;
+		this.compCount = 0;
+		this.cmd(
+			act.createLabel,
+			this.comparisonCountID,
+			'Comparison Count: ' + this.compCount,
+			COMP_COUNT_X,
+			COMP_COUNT_Y,
+		);
+
+		this.animationManager.startNewAnimation(this.commands);
 		this.animationManager.skipForward();
 		this.animationManager.clearHistory();
 	}
 
 	reset() {
 		this.nextIndex = 0;
+		this.compCount = 0;
 		this.arrayData = [];
 		this.arrayID = [];
 		this.displayData = [];
@@ -116,10 +132,10 @@ export default class CocktailSort extends Algorithm {
 	sortCallback() {
 		const list = this.listField.value.split(',').filter(x => x !== '');
 		if (
-			this.listField.value !== ''
-			&& list.length <= MAX_ARRAY_SIZE
-			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
-			) {
+			this.listField.value !== '' &&
+			list.length <= MAX_ARRAY_SIZE &&
+			list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+		) {
 			this.implementAction(this.clear.bind(this));
 			this.listField.value = '';
 			this.implementAction(this.sort.bind(this), list);
@@ -137,6 +153,7 @@ export default class CocktailSort extends Algorithm {
 	clear() {
 		this.arrayData = [];
 		this.commands = [];
+		this.compCount = 0;
 		this.displayData = [];
 		for (let i = 0; i < this.arrayID.length; i++) {
 			this.cmd(act.delete, this.arrayID[i]);
@@ -214,6 +231,11 @@ export default class CocktailSort extends Algorithm {
 			sorted = true;
 			for (let i = start; i < end; i++) {
 				this.movePointers(i, i + 1);
+				this.cmd(
+					act.setText,
+					this.comparisonCountID,
+					'Comparison Count: ' + ++this.compCount,
+				);
 				if (this.arrayData[i] > this.arrayData[i + 1]) {
 					this.swap(i, i + 1);
 					sorted = false;
@@ -235,6 +257,11 @@ export default class CocktailSort extends Algorithm {
 				sorted = true;
 				for (let i = end; i > start; i--) {
 					this.movePointers(i - 1, i);
+					this.cmd(
+						act.setText,
+						this.comparisonCountID,
+						'Comparison Count: ' + ++this.compCount,
+					);
 					if (+this.arrayData[i] < +this.arrayData[i - 1]) {
 						this.swap(i, i - 1);
 						sorted = false;

--- a/src/algo/InsertionSort.js
+++ b/src/algo/InsertionSort.js
@@ -24,11 +24,11 @@
 // authors and should not be interpreted as representing official policies, either expressed
 // or implied, of the University of San Francisco
 
-import Algorithm, { 
+import Algorithm, {
 	addControlToAlgorithmBar,
 	addDivisorToAlgorithmBar,
 	addGroupToAlgorithmBar,
-	addLabelToAlgorithmBar 
+	addLabelToAlgorithmBar,
 } from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
 
@@ -38,6 +38,9 @@ const ARRAY_START_X = 100;
 const ARRAY_START_Y = 200;
 const ARRAY_ELEM_WIDTH = 50;
 const ARRAY_ELEM_HEIGHT = 50;
+
+const COMP_COUNT_X = 100;
+const COMP_COUNT_Y = 50;
 
 export default class InsertionSort extends Algorithm {
 	constructor(am, w, h) {
@@ -52,14 +55,14 @@ export default class InsertionSort extends Algorithm {
 
 		const verticalGroup = addGroupToAlgorithmBar(false);
 
-        addLabelToAlgorithmBar(
+		addLabelToAlgorithmBar(
 			'Comma seperated list (e.g. "3,1,2"). Max 18 elements & no elements > 999',
-			verticalGroup
+			verticalGroup,
 		);
 
 		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
 
-        // List text field
+		// List text field
 		this.listField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.listField.onkeydown = this.returnSubmit(
 			this.listField,
@@ -83,13 +86,24 @@ export default class InsertionSort extends Algorithm {
 	}
 
 	setup() {
+		this.commands = [];
 		this.arrayData = [];
 		this.arrayID = [];
 		this.displayData = [];
 		this.iPointerID = this.nextIndex++;
 		this.jPointerID = this.nextIndex++;
+		this.comparisonCountID = this.nextIndex++;
 
-		this.animationManager.startNewAnimation();
+		this.compCount = 0;
+		this.cmd(
+			act.createLabel,
+			this.comparisonCountID,
+			'Comparison Count: ' + this.compCount,
+			COMP_COUNT_X,
+			COMP_COUNT_Y,
+		);
+
+		this.animationManager.startNewAnimation(this.commands);
 		this.animationManager.skipForward();
 		this.animationManager.clearHistory();
 	}
@@ -101,15 +115,17 @@ export default class InsertionSort extends Algorithm {
 		this.displayData = [];
 		this.iPointerID = this.nextIndex++;
 		this.jPointerID = this.nextIndex++;
+		this.comparisonCountID = this.nextIndex++;
+		this.compCount = 0;
 	}
 
 	sortCallback() {
 		const list = this.listField.value.split(',').filter(x => x !== '');
 		if (
-			this.listField.value !== ''
-			&& list.length <= MAX_ARRAY_SIZE
-			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
-			) {
+			this.listField.value !== '' &&
+			list.length <= MAX_ARRAY_SIZE &&
+			list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+		) {
 			this.implementAction(this.clear.bind(this));
 			this.listField.value = '';
 			this.implementAction(this.sort.bind(this), list);
@@ -128,6 +144,8 @@ export default class InsertionSort extends Algorithm {
 		this.arrayData = [];
 		this.arrayID = [];
 		this.displayData = [];
+		this.compCount = 0;
+		this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + this.compCount);
 		return this.commands;
 	}
 
@@ -195,6 +213,11 @@ export default class InsertionSort extends Algorithm {
 		for (let i = 1; i < this.arrayData.length; i++) {
 			for (let j = i; j >= 1; j--) {
 				this.movePointers(j - 1, j);
+				this.cmd(
+					act.setText,
+					this.comparisonCountID,
+					'Comparison Count: ' + ++this.compCount,
+				);
 				if (this.arrayData[j] < this.arrayData[j - 1]) {
 					this.swap(j, j - 1);
 				} else {

--- a/src/algo/MergeSort.js
+++ b/src/algo/MergeSort.js
@@ -127,9 +127,9 @@ export default class MergeSort extends Algorithm {
 			COMP_COUNT_Y,
 		);
 
-	this.animationManager.startNewAnimation(this.commands);
-	this.animationManager.skipForward();
-	this.animationManager.clearHistory();
+		this.animationManager.startNewAnimation(this.commands);
+		this.animationManager.skipForward();
+		this.animationManager.clearHistory();
 	}
 
 	reset() {

--- a/src/algo/MergeSort.js
+++ b/src/algo/MergeSort.js
@@ -24,21 +24,24 @@
 // authors and should not be interpreted as representing official policies, either expressed
 // or implied, of the University of San Francisco
 
-import Algorithm, { 
+import Algorithm, {
 	addControlToAlgorithmBar,
 	addDivisorToAlgorithmBar,
 	addGroupToAlgorithmBar,
-	addLabelToAlgorithmBar 
+	addLabelToAlgorithmBar,
 } from './Algorithm.js';
 import { act } from '../anim/AnimationMain';
 
 const MAX_ARRAY_SIZE = 18;
 
-const ARRAY_START_X = 120;
+const ARRAY_START_X = 250;
 const ARRAY_START_Y = 50;
 const ARRAY_LINE_SPACING = 80;
 const ARRAY_ELEM_WIDTH = 50;
 const ARRAY_ELEM_HEIGHT = 50;
+
+const COMP_COUNT_X = 100;
+const COMP_COUNT_Y = 50;
 
 // const ARRRAY_ELEMS_PER_LINE = 15;
 
@@ -76,14 +79,14 @@ export default class MergeSort extends Algorithm {
 
 		const verticalGroup = addGroupToAlgorithmBar(false);
 
-        addLabelToAlgorithmBar(
+		addLabelToAlgorithmBar(
 			'Comma seperated list (e.g. "3,1,2"). Max 18 elements & no elements > 999',
-			verticalGroup
+			verticalGroup,
 		);
 
 		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
 
-        // List text field
+		// List text field
 		this.listField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.listField.onkeydown = this.returnSubmit(
 			this.listField,
@@ -107,11 +110,26 @@ export default class MergeSort extends Algorithm {
 	}
 
 	setup() {
+		this.commands = [];
 		this.arrayData = [];
 		this.arrayID = [];
 		this.iPointerID = 0;
 		this.jPointerID = 0;
 		this.kPointerID = 0;
+		this.comparisonCountID = this.nextIndex++;
+
+		this.compCount = 0;
+		this.cmd(
+			act.createLabel,
+			this.comparisonCountID,
+			'Comparison Count: ' + this.compCount,
+			COMP_COUNT_X,
+			COMP_COUNT_Y,
+		);
+
+	this.animationManager.startNewAnimation(this.commands);
+	this.animationManager.skipForward();
+	this.animationManager.clearHistory();
 	}
 
 	reset() {
@@ -121,15 +139,17 @@ export default class MergeSort extends Algorithm {
 		this.iPointerID = 0;
 		this.jPointerID = 0;
 		this.kPointerID = 0;
+		this.comparisonCountID = this.nextIndex++;
+		this.compCount = 0;
 	}
 
 	sortCallback() {
 		const list = this.listField.value.split(',').filter(x => x !== '');
 		if (
-			this.listField.value !== ''
-			&& list.length <= MAX_ARRAY_SIZE
-			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
-			) {
+			this.listField.value !== '' &&
+			list.length <= MAX_ARRAY_SIZE &&
+			list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+		) {
 			this.implementAction(this.clear.bind(this));
 			this.listField.value = '';
 			this.implementAction(this.sort.bind(this), list);
@@ -148,6 +168,8 @@ export default class MergeSort extends Algorithm {
 		this.arrayData = [];
 		this.displayData = [];
 		this.arrayID = [];
+		this.compCount = 0;
+		this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + this.compCount);
 		return this.commands;
 	}
 
@@ -320,6 +342,7 @@ export default class MergeSort extends Algorithm {
 		let j = mid;
 		let k = left;
 		while (i < mid && j <= right) {
+			this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
 			if (tempArray[i] <= tempArray[j]) {
 				this.copyData(
 					i,

--- a/src/algo/QueueArray.js
+++ b/src/algo/QueueArray.js
@@ -567,8 +567,12 @@ export default class QueueArray extends Algorithm {
 		this.size = 0;
 		this.cmd(act.setText, this.frontID, '0');
 		this.cmd(act.setText, this.sizeID, '0');
-		this.cmd(act.setPosition, this.frontPointerID, ARRAY_START_X,
-			ARRAY_START_Y + FRONT_LABEL_OFFSET);
+		this.cmd(
+			act.setPosition,
+			this.frontPointerID,
+			ARRAY_START_X,
+			ARRAY_START_Y + FRONT_LABEL_OFFSET,
+		);
 		return this.commands;
 	}
 }

--- a/src/algo/QuickSelect.js
+++ b/src/algo/QuickSelect.js
@@ -40,6 +40,9 @@ const ARRAY_START_Y = 200;
 const ARRAY_ELEM_WIDTH = 50;
 const ARRAY_ELEM_HEIGHT = 50;
 
+const COMP_COUNT_X = 100;
+const COMP_COUNT_Y = 50;
+
 export default class QuickSelect extends Algorithm {
 	constructor(am, w, h) {
 		super(am, w, h);
@@ -53,14 +56,14 @@ export default class QuickSelect extends Algorithm {
 
 		const verticalGroup = addGroupToAlgorithmBar(false);
 
-        addLabelToAlgorithmBar(
+		addLabelToAlgorithmBar(
 			`Comma seperated list (e.g. "3,1,2"). Max ${MAX_ARRAY_SIZE} elements & no elements > 999`,
-			verticalGroup
+			verticalGroup,
 		);
 
 		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
 
-        // List text field
+		// List text field
 		this.listField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.listField.onkeydown = this.returnSubmit(
 			this.listField,
@@ -107,7 +110,7 @@ export default class QuickSelect extends Algorithm {
 		this.pivotType = 'random';
 
 		addDivisorToAlgorithmBar();
-		
+
 		// Clear button
 		this.clearButton = addControlToAlgorithmBar('Button', 'Clear');
 		this.clearButton.onclick = this.clearCallback.bind(this);
@@ -115,14 +118,25 @@ export default class QuickSelect extends Algorithm {
 	}
 
 	setup() {
+		this.commands = [];
 		this.arrayData = [];
 		this.displayData = [];
 		this.arrayID = [];
 		this.iPointerID = 0;
 		this.jPointerID = 0;
 		this.pPointerID = 0;
+		this.comparisonCountID = this.nextIndex++;
 
-		this.animationManager.startNewAnimation();
+		this.compCount = 0;
+		this.cmd(
+			act.createLabel,
+			this.comparisonCountID,
+			'Comparison Count: ' + this.compCount,
+			COMP_COUNT_X,
+			COMP_COUNT_Y,
+		);
+
+		this.animationManager.startNewAnimation(this.commands);
 		this.animationManager.skipForward();
 		this.animationManager.clearHistory();
 	}
@@ -135,16 +149,18 @@ export default class QuickSelect extends Algorithm {
 		this.iPointerID = 0;
 		this.jPointerID = 0;
 		this.pPointerID = 0;
+		this.comparisonCountID = this.nextIndex++;
+		this.compCount = 0;
 	}
 
 	runCallback() {
 		const list = this.listField.value.split(',').filter(x => x !== '');
 		if (
-			this.listField.value !== '' 
-			&& this.kField.value !== ''
-			&& list.length <= MAX_ARRAY_SIZE
-			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
-			) {
+			this.listField.value !== '' &&
+			this.kField.value !== '' &&
+			list.length <= MAX_ARRAY_SIZE &&
+			list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+		) {
 			const k = this.kField.value;
 			if (k > 0 && k <= list.length) {
 				this.implementAction(this.clear.bind(this));
@@ -167,6 +183,8 @@ export default class QuickSelect extends Algorithm {
 		this.arrayData = [];
 		this.arrayID = [];
 		this.displayData = [];
+		this.compCount = 0;
+		this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + this.compCount);
 		return this.commands;
 	}
 
@@ -276,18 +294,22 @@ export default class QuickSelect extends Algorithm {
 		this.cmd(act.step);
 		while (i <= j) {
 			while (i <= j && this.arrayData[left] >= this.arrayData[i]) {
+				this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
 				i++;
 				this.movePointers(i, j);
 			}
 			if (i <= j) {
+				this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
 				this.cmd(act.setForegroundColor, this.iPointerID, '#FF0000');
 				this.cmd(act.step);
 			}
 			while (i <= j && this.arrayData[left] <= this.arrayData[j]) {
+				this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
 				j--;
 				this.movePointers(i, j);
 			}
 			if (i <= j) {
+				this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
 				this.cmd(act.setForegroundColor, this.jPointerID, '#FF0000');
 				this.cmd(act.step);
 			}

--- a/src/algo/QuickSelect.js
+++ b/src/algo/QuickSelect.js
@@ -294,22 +294,38 @@ export default class QuickSelect extends Algorithm {
 		this.cmd(act.step);
 		while (i <= j) {
 			while (i <= j && this.arrayData[left] >= this.arrayData[i]) {
-				this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
+				this.cmd(
+					act.setText,
+					this.comparisonCountID,
+					'Comparison Count: ' + ++this.compCount,
+				);
 				i++;
 				this.movePointers(i, j);
 			}
 			if (i <= j) {
-				this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
+				this.cmd(
+					act.setText,
+					this.comparisonCountID,
+					'Comparison Count: ' + ++this.compCount,
+				);
 				this.cmd(act.setForegroundColor, this.iPointerID, '#FF0000');
 				this.cmd(act.step);
 			}
 			while (i <= j && this.arrayData[left] <= this.arrayData[j]) {
-				this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
+				this.cmd(
+					act.setText,
+					this.comparisonCountID,
+					'Comparison Count: ' + ++this.compCount,
+				);
 				j--;
 				this.movePointers(i, j);
 			}
 			if (i <= j) {
-				this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
+				this.cmd(
+					act.setText,
+					this.comparisonCountID,
+					'Comparison Count: ' + ++this.compCount,
+				);
 				this.cmd(act.setForegroundColor, this.jPointerID, '#FF0000');
 				this.cmd(act.step);
 			}

--- a/src/algo/QuickSort.js
+++ b/src/algo/QuickSort.js
@@ -40,6 +40,9 @@ const ARRAY_START_Y = 200;
 const ARRAY_ELEM_WIDTH = 50;
 const ARRAY_ELEM_HEIGHT = 50;
 
+const COMP_COUNT_X = 100;
+const COMP_COUNT_Y = 50;
+
 export default class QuickSort extends Algorithm {
 	constructor(am, w, h) {
 		super(am, w, h);
@@ -53,14 +56,14 @@ export default class QuickSort extends Algorithm {
 
 		const verticalGroup = addGroupToAlgorithmBar(false);
 
-        addLabelToAlgorithmBar(
+		addLabelToAlgorithmBar(
 			'Comma seperated list (e.g. "3,1,2"). Max 18 elements & no elements > 999',
-			verticalGroup
+			verticalGroup,
 		);
 
 		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
 
-        // List text field
+		// List text field
 		this.listField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.listField.onkeydown = this.returnSubmit(
 			this.listField,
@@ -105,14 +108,25 @@ export default class QuickSort extends Algorithm {
 	}
 
 	setup() {
+		this.commands = [];
 		this.arrayData = [];
 		this.displayData = [];
 		this.arrayID = [];
 		this.iPointerID = 0;
 		this.jPointerID = 0;
 		this.pPointerID = 0;
+		this.comparisonCountID = this.nextIndex++;
 
-		this.animationManager.startNewAnimation();
+		this.compCount = 0;
+		this.cmd(
+			act.createLabel,
+			this.comparisonCountID,
+			'Comparison Count: ' + this.compCount,
+			COMP_COUNT_X,
+			COMP_COUNT_Y,
+		);
+
+		this.animationManager.startNewAnimation(this.commands);
 		this.animationManager.skipForward();
 		this.animationManager.clearHistory();
 	}
@@ -125,15 +139,17 @@ export default class QuickSort extends Algorithm {
 		this.iPointerID = 0;
 		this.jPointerID = 0;
 		this.pPointerID = 0;
+		this.comparisonCountID = this.nextIndex++;
+		this.compCount = 0;
 	}
 
 	sortCallback() {
 		const list = this.listField.value.split(',').filter(x => x !== '');
 		if (
-			this.listField.value !== ''
-			&& list.length <= MAX_ARRAY_SIZE
-			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
-			) {
+			this.listField.value !== '' &&
+			list.length <= MAX_ARRAY_SIZE &&
+			list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+		) {
 			this.implementAction(this.clear.bind(this));
 			this.listField.value = '';
 			this.implementAction(this.sort.bind(this), list);
@@ -152,6 +168,8 @@ export default class QuickSort extends Algorithm {
 		this.arrayData = [];
 		this.arrayID = [];
 		this.displayData = [];
+		this.compCount = 0;
+		this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + this.compCount);
 		return this.commands;
 	}
 
@@ -260,18 +278,23 @@ export default class QuickSort extends Algorithm {
 		while (i <= j) {
 			while (i <= j && this.arrayData[left] >= this.arrayData[i]) {
 				i++;
+				this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
 				this.movePointers(i, j);
 			}
 			if (i <= j) {
 				this.cmd(act.setForegroundColor, this.iPointerID, '#FF0000');
+				// One additional comparison will be made in the above loop if i <= j
+				this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
 				this.cmd(act.step);
 			}
 			while (i <= j && this.arrayData[left] <= this.arrayData[j]) {
 				j--;
+				this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
 				this.movePointers(i, j);
 			}
 			if (i <= j) {
 				this.cmd(act.setForegroundColor, this.jPointerID, '#FF0000');
+				this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
 				this.cmd(act.step);
 			}
 			if (i <= j) {

--- a/src/algo/QuickSort.js
+++ b/src/algo/QuickSort.js
@@ -278,23 +278,39 @@ export default class QuickSort extends Algorithm {
 		while (i <= j) {
 			while (i <= j && this.arrayData[left] >= this.arrayData[i]) {
 				i++;
-				this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
+				this.cmd(
+					act.setText,
+					this.comparisonCountID,
+					'Comparison Count: ' + ++this.compCount,
+				);
 				this.movePointers(i, j);
 			}
 			if (i <= j) {
 				this.cmd(act.setForegroundColor, this.iPointerID, '#FF0000');
 				// One additional comparison will be made in the above loop if i <= j
-				this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
+				this.cmd(
+					act.setText,
+					this.comparisonCountID,
+					'Comparison Count: ' + ++this.compCount,
+				);
 				this.cmd(act.step);
 			}
 			while (i <= j && this.arrayData[left] <= this.arrayData[j]) {
 				j--;
-				this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
+				this.cmd(
+					act.setText,
+					this.comparisonCountID,
+					'Comparison Count: ' + ++this.compCount,
+				);
 				this.movePointers(i, j);
 			}
 			if (i <= j) {
 				this.cmd(act.setForegroundColor, this.jPointerID, '#FF0000');
-				this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
+				this.cmd(
+					act.setText,
+					this.comparisonCountID,
+					'Comparison Count: ' + ++this.compCount,
+				);
 				this.cmd(act.step);
 			}
 			if (i <= j) {

--- a/src/algo/SelectionSort.js
+++ b/src/algo/SelectionSort.js
@@ -40,6 +40,9 @@ const ARRAY_START_Y = 200;
 const ARRAY_ELEM_WIDTH = 50;
 const ARRAY_ELEM_HEIGHT = 50;
 
+const COMP_COUNT_X = 100;
+const COMP_COUNT_Y = 50;
+
 // const ARRRAY_ELEMS_PER_LINE = 15;
 // const ARRAY_LINE_SPACING = 130;
 
@@ -68,14 +71,14 @@ export default class SelectionSort extends Algorithm {
 
 		const verticalGroup = addGroupToAlgorithmBar(false);
 
-        addLabelToAlgorithmBar(
+		addLabelToAlgorithmBar(
 			'Comma seperated list (e.g. "3,1,2"). Max 18 elements & no elements > 999',
-			verticalGroup
+			verticalGroup,
 		);
 
 		const horizontalGroup = addGroupToAlgorithmBar(true, verticalGroup);
 
-        // List text field
+		// List text field
 		this.listField = addControlToAlgorithmBar('Text', '', horizontalGroup);
 		this.listField.onkeydown = this.returnSubmit(
 			this.listField,
@@ -111,13 +114,24 @@ export default class SelectionSort extends Algorithm {
 	}
 
 	setup() {
+		this.commands = [];
 		this.arrayData = [];
 		this.arrayID = [];
 		this.displayData = [];
 		this.iPointerID = this.nextIndex++;
 		this.jPointerID = this.nextIndex++;
+		this.comparisonCountID = this.nextIndex++;
 
-		this.animationManager.startNewAnimation();
+		this.compCount = 0;
+		this.cmd(
+			act.createLabel,
+			this.comparisonCountID,
+			'Comparison Count: ' + this.compCount,
+			COMP_COUNT_X,
+			COMP_COUNT_Y,
+		);
+
+		this.animationManager.startNewAnimation(this.commands);
 		this.animationManager.skipForward();
 		this.animationManager.clearHistory();
 	}
@@ -129,6 +143,8 @@ export default class SelectionSort extends Algorithm {
 		this.displayData = [];
 		this.iPointerID = this.nextIndex++;
 		this.jPointerID = this.nextIndex++;
+		this.comparisonCountID = this.nextIndex++;
+		this.compCount = 0;
 	}
 
 	minCallback() {
@@ -148,10 +164,10 @@ export default class SelectionSort extends Algorithm {
 	sortCallback() {
 		const list = this.listField.value.split(',').filter(x => x !== '');
 		if (
-			this.listField.value !== ''
-			&& list.length <= MAX_ARRAY_SIZE
-			&& list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
-			) {
+			this.listField.value !== '' &&
+			list.length <= MAX_ARRAY_SIZE &&
+			list.map(Number).filter(x => x > 999 || Number.isNaN(x)).length <= 0
+		) {
 			this.implementAction(this.clear.bind(this));
 			this.listField.value = '';
 			this.implementAction(this.sort.bind(this), list);
@@ -164,12 +180,16 @@ export default class SelectionSort extends Algorithm {
 
 	clear() {
 		this.commands = [];
+
 		for (let i = 0; i < this.arrayID.length; i++) {
 			this.cmd(act.delete, this.arrayID[i]);
 		}
+
 		this.arrayData = [];
 		this.arrayID = [];
+		this.compCount = 0;
 		this.displayData = [];
+		this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + this.compCount);
 		return this.commands;
 	}
 
@@ -291,6 +311,7 @@ export default class SelectionSort extends Algorithm {
 	}
 
 	compare(i, j) {
+		this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
 		if (this.isMin) {
 			return i < j;
 		} else {


### PR DESCRIPTION
closes #158 

Sorting algorithms display comparison counts while running! 

<img width="528" alt="Screen Shot 2022-01-28 at 9 35 17 AM" src="https://user-images.githubusercontent.com/67525591/151565257-72353a25-0ec6-4731-8c17-5091c1d29bdb.png">

Heapsort and LSD Radix don't have this feature because their methods of sorting don't directly compare objects in the typical sense. 

The algorithms are all consistent with the way they are taught in 1332 and the comparison counts match the requirements of our homework (at least it seems that way).