### PR TITLE
Removes extra rows from BM with Galil Rule

### DIFF
--- a/src/algo/BoyerMoore.js
+++ b/src/algo/BoyerMoore.js
@@ -391,6 +391,9 @@ export default class BoyerMoore extends Algorithm {
 					i++;
 				}
 			} else {
+				if (l !== 0) {
+					l = 0;
+				}
 				let shift;
 				if (text.charAt(i + j) in lastTable) {
 					shift = lastTable[text.charAt(i + j)];


### PR DESCRIPTION
Adds some more preprocessing so that the number of empty rows matches the number of alignments when Galil Rule is enabled.