### PR TITLE
Add Pattern Matching Pseudocode

### DIFF
--- a/src/algo/BoyerMoore.js
+++ b/src/algo/BoyerMoore.js
@@ -328,6 +328,7 @@ export default class BoyerMoore extends Algorithm {
 		}
 
 		const lastTable = this.buildLastTable(text.length, pattern);
+		this.removeCode(this.codeID);
 		if (galilRuleEnabled) {
 			this.buildFailureTable(text.length, pattern);
 			this.codeID = this.addCodeToCanvasBase(this.GalilCode, ARRAY_START_X + text.length * this.cellSize + 10, BM_CODE_Y);
@@ -675,7 +676,6 @@ export default class BoyerMoore extends Algorithm {
 		this.highlight(4, 0);
 		this.cmd(act.step);
 		this.unhighlight(4, 0);
-		this.removeCode(this.codeID);
 
 		Object.keys(lastTable).map(char => (lastTable[char] = lastTable[char][0])); // Return only indices
 		return lastTable;

--- a/src/algo/BoyerMoore.js
+++ b/src/algo/BoyerMoore.js
@@ -160,7 +160,7 @@ export default class BoyerMoore extends Algorithm {
 			['                    i <- failureTable[i - 1]'],
 			['     return failureTable'],
 			['end procedure'],
-		]
+		];
 
 		this.BMCode = [
 			['procedure BoyerMoore(text, pattern):'],
@@ -181,7 +181,7 @@ export default class BoyerMoore extends Algorithm {
 			['               else'],
 			['                    i <- i + 1'],
 			['end procedure'],
-		]
+		];
 
 		this.GalilCode = [
 			['procedure BoyerMooreGalil(text, pattern):'],
@@ -204,7 +204,7 @@ export default class BoyerMoore extends Algorithm {
 			['               else'],
 			['                    i <- i + 1'],
 			['end procedure'],
-		]
+		];
 
 		this.compCount = 0;
 		this.cmd(act.createLabel, this.comparisonCountID, '', COMP_COUNT_X, COMP_COUNT_Y, 0);
@@ -331,9 +331,17 @@ export default class BoyerMoore extends Algorithm {
 		this.removeCode(this.codeID);
 		if (galilRuleEnabled) {
 			this.buildFailureTable(text.length, pattern);
-			this.codeID = this.addCodeToCanvasBase(this.GalilCode, ARRAY_START_X + text.length * this.cellSize + 10, BM_CODE_Y);
+			this.codeID = this.addCodeToCanvasBase(
+				this.GalilCode,
+				ARRAY_START_X + text.length * this.cellSize + 10,
+				BM_CODE_Y,
+			);
 		} else {
-			this.codeID = this.addCodeToCanvasBase(this.BMCode, ARRAY_START_X + text.length * this.cellSize + 10, BM_CODE_Y);
+			this.codeID = this.addCodeToCanvasBase(
+				this.BMCode,
+				ARRAY_START_X + text.length * this.cellSize + 10,
+				BM_CODE_Y,
+			);
 		}
 
 		const iPointerID = this.nextIndex++;
@@ -606,7 +614,7 @@ export default class BoyerMoore extends Algorithm {
 		);
 		this.cmd(act.setHighlight, lotPointerID, 1);
 		this.highlight(2, 0);
-		
+
 		for (let i = 0; i < pattern.length; i++) {
 			this.cmd(act.step);
 			let xpos = patternTableStartX + i * this.cellSize;

--- a/src/algo/BruteForce.js
+++ b/src/algo/BruteForce.js
@@ -39,6 +39,8 @@ const MAX_LENGTH = 22;
 const COMP_COUNT_X = 575;
 const COMP_COUNT_Y = 30;
 
+const CODE_Y = 120;
+
 export default class BruteForce extends Algorithm {
 	constructor(am, w, h) {
 		super(am, w, h);
@@ -91,6 +93,19 @@ export default class BruteForce extends Algorithm {
 		this.commands = [];
 		this.textRowID = [];
 		this.comparisonMatrixID = [];
+		this.codeID = [];
+
+		this.code = [
+			['procedure BruteForce(text, pattern)'],
+			['     n <- text.length, m <- pattern.length'],
+			['     for i <- 0, n - m'],
+			['          j <- 0'],
+			['          while j < m and pattern[j] = text[i + j]'],
+			['               j <- j + 1'],
+			['          if j = m'],
+			['               match found at i'],
+			['end procedure'],
+		];
 
 		this.comparisonCountID = this.nextIndex++;
 
@@ -108,6 +123,7 @@ export default class BruteForce extends Algorithm {
 		this.comparisonMatrixID = [];
 		this.comparisonCountID = this.nextIndex++;
 		this.compCount = 0;
+		this.codeID = [];
 	}
 
 	findCallback() {
@@ -185,6 +201,8 @@ export default class BruteForce extends Algorithm {
 			}
 		}
 
+		this.codeID = this.addCodeToCanvasBase(this.code, labelsX, CODE_Y);
+
 		const iPointerID = this.nextIndex++;
 		const jPointerID = this.nextIndex++;
 		this.cmd(
@@ -207,6 +225,8 @@ export default class BruteForce extends Algorithm {
 		let i = 0;
 		let j = 0;
 		let row = 0;
+		this.highlight(2, 0);
+		this.cmd(act.step);
 		while (i <= text.length - pattern.length) {
 			for (let k = i; k < i + pattern.length; k++) {
 				this.cmd(
@@ -217,6 +237,10 @@ export default class BruteForce extends Algorithm {
 					ypos,
 				);
 			}
+			this.highlight(3, 0);
+			this.cmd(act.step);
+			this.unhighlight(3, 0);
+			this.highlight(4, 0);
 			this.cmd(act.step);
 			while (j < pattern.length && pattern.charAt(j) === text.charAt(i + j)) {
 				this.cmd(
@@ -226,15 +250,18 @@ export default class BruteForce extends Algorithm {
 				);
 				this.cmd(act.setBackgroundColor, this.comparisonMatrixID[row][i + j], '#2ECC71');
 				j++;
+				this.highlight(5, 0);
 				this.cmd(act.step);
+				this.unhighlight(5, 0);
 				if (j !== pattern.length) {
 					const xpos = (i + j) * this.cellSize + ARRAY_START_X;
 					this.cmd(act.move, iPointerID, xpos, ARRAY_START_Y);
 					const ypos = (row + 1) * this.cellSize + ARRAY_START_Y;
 					this.cmd(act.move, jPointerID, xpos, ypos);
-					this.cmd(act.step);
 				}
+				this.cmd(act.step);
 			}
+			this.unhighlight(4, 0);
 			if (j < pattern.length) {
 				this.cmd(
 					act.setText,
@@ -242,8 +269,15 @@ export default class BruteForce extends Algorithm {
 					'Comparison Count: ' + ++this.compCount,
 				);
 			}
+			this.highlight(6, 0);
+			this.cmd(act.step);
+			this.unhighlight(6, 0);
 			if (j !== pattern.length) {
 				this.cmd(act.setBackgroundColor, this.comparisonMatrixID[row][i + j], '#E74C3C');
+			} else {
+				this.highlight(7, 0);
+				this.cmd(act.step);
+				this.unhighlight(7, 0);
 			}
 			i++;
 			j = 0;
@@ -256,6 +290,7 @@ export default class BruteForce extends Algorithm {
 				this.cmd(act.step);
 			}
 		}
+		this.unhighlight(2, 0);
 
 		this.cmd(act.delete, iPointerID);
 		this.cmd(act.delete, jPointerID);
@@ -274,6 +309,8 @@ export default class BruteForce extends Algorithm {
 			}
 		}
 		this.comparisonMatrixID = [];
+		this.removeCode(this.codeID);
+		this.codeID = [];
 		this.compCount = 0;
 		this.cmd(act.setText, this.comparisonCountID, '');
 		return this.commands;

--- a/src/algo/KMP.js
+++ b/src/algo/KMP.js
@@ -130,7 +130,7 @@ export default class KMP extends Algorithm {
 			['                    i <- failureTable[i - 1]'],
 			['     return failureTable'],
 			['end procedure'],
-		]
+		];
 
 		this.KMPCode = [
 			['procedure KMP(text, pattern):'],
@@ -149,7 +149,7 @@ export default class KMP extends Algorithm {
 			['               i <- i + j - shift'],
 			['               j <- shift'],
 			['end procedure'],
-		]
+		];
 
 		this.animationManager.startNewAnimation(this.commands);
 		this.animationManager.skipForward();
@@ -252,7 +252,11 @@ export default class KMP extends Algorithm {
 		this.removeCode(this.codeID);
 		const tableStartX = ARRAY_START_X + text.length * this.cellSize + 110;
 
-		this.codeID = this.addCodeToCanvasBase(this.KMPCode, ARRAY_START_X + text.length * this.cellSize + 10, CODE_Y);
+		this.codeID = this.addCodeToCanvasBase(
+			this.KMPCode,
+			ARRAY_START_X + text.length * this.cellSize + 10,
+			CODE_Y,
+		);
 
 		const iPointerID = this.nextIndex++;
 		const jPointerID = this.nextIndex++;

--- a/src/algo/KMP.js
+++ b/src/algo/KMP.js
@@ -41,6 +41,8 @@ const FAILURE_TABLE_START_Y = 100;
 const COMP_COUNT_X = 575;
 const COMP_COUNT_Y = 30;
 
+const CODE_Y = 195;
+
 export default class KMP extends Algorithm {
 	constructor(am, w, h) {
 		super(am, w, h);
@@ -103,11 +105,51 @@ export default class KMP extends Algorithm {
 		this.failureTableLabelID = this.nextIndex++;
 		this.failureTableCharacterID = [];
 		this.failureTableValueID = [];
+		this.codeID = [];
 
 		this.comparisonCountID = this.nextIndex++;
 
 		this.compCount = 0;
 		this.cmd(act.createLabel, this.comparisonCountID, '', COMP_COUNT_X, COMP_COUNT_Y, 0);
+
+		this.failureTableCode = [
+			['procedure KMPFailureTable(pattern):'],
+			['     m <- length of pattern'],
+			['     failureTable <- array of length m'],
+			['     i <- 0, j <- 1'],
+			['     failureTable[0] <- 0'],
+			['     while j < m'],
+			['          if pattern[i] = pattern[j]'],
+			['               failureTable[j] <- i + 1'],
+			['               i < i + 1, j <- j + 1'],
+			['          else'],
+			['               if i = 0'],
+			['                    failureTable[j] <- 0'],
+			['                    j <- j + 1'],
+			['               else'],
+			['                    i <- failureTable[i - 1]'],
+			['     return failureTable'],
+			['end procedure'],
+		]
+
+		this.KMPCode = [
+			['procedure KMP(text, pattern):'],
+			['     initialize failureTable'],
+			['     m <- length of pattern, n <- length of text'],
+			['     i <- 0, j <- 0'],
+			['     while i <= n - m'],
+			['          while j < m and text[i + j] = pattern[j]'],
+			['               j -> j + 1'],
+			['          if j = 0'],
+			['               i <- i + 1'],
+			['          else'],
+			['               if j = m'],
+			['                    match found at i'],
+			['               shift <- failureTable[j - 1]'],
+			['               i <- i + j - shift'],
+			['               j <- shift'],
+			['end procedure'],
+		]
 
 		this.animationManager.startNewAnimation(this.commands);
 		this.animationManager.skipForward();
@@ -121,6 +163,7 @@ export default class KMP extends Algorithm {
 		this.failureTableLabelID = this.nextIndex++;
 		this.failureTableCharacterID = [];
 		this.failureTableValueID = [];
+		this.codeID = [];
 		this.comparisonCountID = this.nextIndex++;
 		this.compCount = 0;
 	}
@@ -206,7 +249,10 @@ export default class KMP extends Algorithm {
 		}
 
 		const failureTable = this.buildFailureTable(text.length, pattern);
+		this.removeCode(this.codeID);
 		const tableStartX = ARRAY_START_X + text.length * this.cellSize + 110;
+
+		this.codeID = this.addCodeToCanvasBase(this.KMPCode, ARRAY_START_X + text.length * this.cellSize + 10, CODE_Y);
 
 		const iPointerID = this.nextIndex++;
 		const jPointerID = this.nextIndex++;
@@ -260,6 +306,7 @@ export default class KMP extends Algorithm {
 		let i = 0;
 		let j = 0;
 		let row = 0;
+		this.highlight(4, 0);
 		while (i <= text.length - pattern.length) {
 			for (let k = i; k < i + pattern.length; k++) {
 				this.cmd(
@@ -274,6 +321,7 @@ export default class KMP extends Algorithm {
 				}
 			}
 			this.cmd(act.step);
+			this.highlight(5, 0);
 			this.cmd(act.setAlpha, fjPointerID, 0);
 			this.cmd(act.setAlpha, f0PointerID, 0);
 			this.cmd(act.setAlpha, f1PointerID, 0);
@@ -285,7 +333,9 @@ export default class KMP extends Algorithm {
 				);
 				this.cmd(act.setBackgroundColor, this.comparisonMatrixID[row][i + j], '#2ECC71');
 				j++;
+				this.highlight(6, 0);
 				this.cmd(act.step);
+				this.unhighlight(6, 0);
 				if (j < pattern.length) {
 					xpos = (i + j) * this.cellSize + ARRAY_START_X;
 					this.cmd(act.move, iPointerID, xpos, ARRAY_START_Y);
@@ -294,6 +344,7 @@ export default class KMP extends Algorithm {
 					this.cmd(act.step);
 				}
 			}
+			this.unhighlight(5, 0);
 			if (j < pattern.length) {
 				this.cmd(
 					act.setText,
@@ -301,17 +352,35 @@ export default class KMP extends Algorithm {
 					'Comparison Count: ' + ++this.compCount,
 				);
 			}
+			this.highlight(7, 0);
+			this.cmd(act.step);
 			if (j === 0) {
+				this.unhighlight(7, 0);
+				this.highlight(8, 0);
+				this.cmd(act.step);
+				this.unhighlight(8, 0);
 				this.cmd(act.setBackgroundColor, this.comparisonMatrixID[row][i], '#E74C3C');
 				i++;
 			} else {
+				this.unhighlight(7, 0);
+				this.highlight(9, 0);
+				this.cmd(act.step);
+				this.unhighlight(9, 0);
+				this.highlight(10, 0);
+				this.cmd(act.step);
+				this.unhighlight(10, 0);
 				if (j !== pattern.length) {
 					this.cmd(
 						act.setBackgroundColor,
 						this.comparisonMatrixID[row][i + j],
 						'#E74C3C',
 					);
+				} else {
+					this.highlight(11, 0);
+					this.cmd(act.step);
+					this.unhighlight(11, 0);
 				}
+				this.highlight(12, 0);
 				const nextAlignment = failureTable[j - 1];
 				this.cmd(
 					act.setPosition,
@@ -334,6 +403,10 @@ export default class KMP extends Algorithm {
 				this.cmd(act.setAlpha, fjPointerID, 1);
 				this.cmd(act.setAlpha, f0PointerID, 1);
 				this.cmd(act.setAlpha, f1PointerID, 1);
+				this.cmd(act.step);
+				this.unhighlight(12, 0);
+				this.highlight(13, 0);
+				this.highlight(14, 0);
 				i += j - nextAlignment;
 				j = nextAlignment;
 			}
@@ -343,9 +416,12 @@ export default class KMP extends Algorithm {
 				this.cmd(act.move, iPointerID, xpos, ARRAY_START_Y);
 				ypos = (row + 1) * this.cellSize + ARRAY_START_Y;
 				this.cmd(act.move, jPointerID, xpos, ypos);
-				this.cmd(act.step);
 			}
+			this.cmd(act.step);
+			this.unhighlight(13, 0);
+			this.unhighlight(14, 0);
 		}
+		this.unhighlight(4, 0);
 
 		this.cmd(act.delete, iPointerID);
 		this.cmd(act.delete, jPointerID);
@@ -412,6 +488,8 @@ export default class KMP extends Algorithm {
 			0,
 		);
 
+		this.codeID = this.addCodeToCanvasBase(this.failureTableCode, labelX, CODE_Y);
+
 		this.cmd(act.move, this.comparisonCountID, labelX, COMP_COUNT_Y);
 		this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + this.compCount);
 
@@ -465,15 +543,25 @@ export default class KMP extends Algorithm {
 			this.cellSize / 2,
 		);
 		this.cmd(act.setText, this.failureTableValueID[0], 0);
+		this.highlight(3, 0);
+		this.highlight(4, 0);
 		this.cmd(act.step);
+		this.unhighlight(3, 0);
+		this.unhighlight(4, 0);
 
 		const failureTable = [];
 		failureTable[0] = 0;
 		let i = 0;
 		let j = 1;
+		this.highlight(5, 0);
 		while (j < pattern.length) {
 			this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + ++this.compCount);
+			this.highlight(6, 0);
+			this.cmd(act.step);
+			this.unhighlight(6, 0);
 			if (pattern.charAt(i) === pattern.charAt(j)) {
+				this.highlight(7, 0);
+				this.highlight(8, 0);
 				i++;
 				failureTable[j] = i;
 				this.cmd(act.setText, this.failureTableValueID[j], i);
@@ -493,8 +581,18 @@ export default class KMP extends Algorithm {
 					);
 				}
 				this.cmd(act.step);
+				this.unhighlight(7, 0);
+				this.unhighlight(8, 0);
 			} else {
+				this.highlight(9, 0);
+				this.cmd(act.step);
+				this.unhighlight(9, 0);
+				this.highlight(10, 0);
+				this.cmd(act.step);
+				this.unhighlight(10, 0);
 				if (i === 0) {
+					this.highlight(11, 0);
+					this.highlight(12, 0);
 					failureTable[j] = i;
 					this.cmd(act.setText, this.failureTableValueID[j], i);
 					j++;
@@ -507,7 +605,13 @@ export default class KMP extends Algorithm {
 						);
 					}
 					this.cmd(act.step);
+					this.unhighlight(11, 0);
+					this.unhighlight(12, 0);
 				} else {
+					this.highlight(13, 0);
+					this.cmd(act.step);
+					this.unhighlight(13, 0);
+					this.highlight(14, 0);
 					i = failureTable[i - 1];
 					this.cmd(
 						act.move,
@@ -516,12 +620,20 @@ export default class KMP extends Algorithm {
 						FAILURE_TABLE_START_Y,
 					);
 					this.cmd(act.step);
+					this.unhighlight(14, 0);
 				}
 			}
 		}
+		this.unhighlight(5, 0);
+		this.highlight(15, 0);
+		this.cmd(act.step);
+		this.unhighlight(15, 0);
 
 		this.cmd(act.delete, iPointerID);
 		this.cmd(act.delete, jPointerID);
+
+		//this.removeCode(this.codeID);
+		//this.codeID = [];
 
 		return failureTable;
 	}
@@ -545,6 +657,10 @@ export default class KMP extends Algorithm {
 			this.cmd(act.delete, this.failureTableCharacterID[i]);
 			this.cmd(act.delete, this.failureTableValueID[i]);
 		}
+
+		this.removeCode(this.codeID);
+		this.codeID = [];
+
 		this.compCount = 0;
 		this.cmd(act.setText, this.comparisonCountID, '');
 		this.failureTableCharacterID = [];

--- a/src/algo/RabinKarp.js
+++ b/src/algo/RabinKarp.js
@@ -46,6 +46,8 @@ const PATTERN_HASH_LABEL_START_Y = 115;
 const COMP_COUNT_X = 575;
 const COMP_COUNT_Y = 30;
 
+const CODE_Y = 180;
+
 export default class RabinKarp extends Algorithm {
 	constructor(am, w, h) {
 		super(am, w, h);
@@ -127,6 +129,26 @@ export default class RabinKarp extends Algorithm {
 		this.compCount = 0;
 		this.cmd(act.createLabel, this.comparisonCountID, '', COMP_COUNT_X, COMP_COUNT_Y, 0);
 
+		this.code = [
+			['procedure RabinKarp(text, pattern)'],
+			['     m <- length of pattern, n <- length of text'],
+			['     patternHash ← rolling hash of pattern'],
+			['     textHash ← rolling hash of first m characters of text'],
+			['     i <- 0'],
+			['     while i <= n - m'],
+			['          if patternHash = textHash'],
+			['               j <- 0'],
+			['               while j < m and text[i + j] = pattern[j]'],
+			['                    j <- j + 1'],
+			['               if j = n'],
+			['                    match found at i'],
+			['          i <- i + 1'],
+			['          if i <= n - m'],
+			['               textHash <- new hash of text, from i to i + m'],
+			['end procedure'],
+		];
+		this.codeID = [];
+
 		this.animationManager.startNewAnimation(this.commands);
 		this.animationManager.skipForward();
 		this.animationManager.clearHistory();
@@ -144,6 +166,7 @@ export default class RabinKarp extends Algorithm {
 		this.patternHashCalculationID = this.nextIndex++;
 		this.comparisonCountID = this.nextIndex++;
 		this.compCount = 0;
+		this.codeID = [];
 	}
 
 	findCallback() {
@@ -266,6 +289,8 @@ export default class RabinKarp extends Algorithm {
 		this.cmd(act.move, this.comparisonCountID, labelsX, COMP_COUNT_Y);
 		this.cmd(act.setText, this.comparisonCountID, 'Comparison Count: ' + this.compCount);
 
+		this.codeID = this.addCodeToCanvasBase(this.code, labelsX, CODE_Y);
+
 		let textCalculation = '';
 		let textHash = 0;
 		let patternCalculation = '';
@@ -304,6 +329,14 @@ export default class RabinKarp extends Algorithm {
 		const iPointerID = this.nextIndex++;
 		const jPointerID = this.nextIndex++;
 
+		this.highlight(2, 0);
+		this.cmd(act.step);
+		this.unhighlight(2, 0);
+		this.highlight(3, 0);
+		this.cmd(act.step);
+		this.unhighlight(3, 0);
+
+		this.highlight(5, 0);
 		let row = 0;
 		for (let i = 0; i <= text.length - pattern.length; i++) {
 			for (let k = i; k < i + pattern.length; k++) {
@@ -316,11 +349,18 @@ export default class RabinKarp extends Algorithm {
 				);
 			}
 			this.cmd(act.step);
+			this.highlight(6, 0);
+			this.cmd(act.step);
 			if (patternHash === textHash) {
+				this.unhighlight(6, 0);
+				this.highlight(7, 0);
 				xpos = i * this.cellSize + ARRAY_START_X;
 				this.cmd(act.createHighlightCircle, iPointerID, '#0000FF', xpos, ARRAY_START_Y);
 				ypos = (row + 1) * this.cellSize + ARRAY_START_Y;
 				this.cmd(act.createHighlightCircle, jPointerID, '#0000FF', xpos, ypos);
+				this.cmd(act.step);
+				this.unhighlight(7, 0);
+				this.highlight(8, 0);
 				this.cmd(act.step);
 				let j = 0;
 				while (j < pattern.length && pattern.charAt(j) === text.charAt(i + j)) {
@@ -335,14 +375,20 @@ export default class RabinKarp extends Algorithm {
 						'#2ECC71',
 					);
 					j++;
+					this.highlight(9, 0);
 					if (j !== pattern.length) {
 						xpos = (i + j) * this.cellSize + ARRAY_START_X;
 						this.cmd(act.move, iPointerID, xpos, ARRAY_START_Y);
 						ypos = (row + 1) * this.cellSize + ARRAY_START_Y;
 						this.cmd(act.move, jPointerID, xpos, ypos);
-						this.cmd(act.step);
 					}
+					this.cmd(act.step);
+					this.unhighlight(9, 0);
 				}
+				this.unhighlight(8, 0);
+				this.highlight(10, 0);
+				this.cmd(act.step);
+				this.unhighlight(10, 0);
 				if (j !== pattern.length) {
 					this.cmd(
 						act.setText,
@@ -354,6 +400,10 @@ export default class RabinKarp extends Algorithm {
 						this.comparisonMatrixID[row][i + j],
 						'#E74C3C',
 					);
+				} else {
+					this.highlight(11, 0);
+					this.cmd(act.step);
+					this.unhighlight(11, 0);
 				}
 				this.cmd(act.delete, iPointerID);
 				this.cmd(act.delete, jPointerID);
@@ -362,9 +412,17 @@ export default class RabinKarp extends Algorithm {
 				for (let k = i; k < i + pattern.length; k++) {
 					this.cmd(act.setBackgroundColor, this.comparisonMatrixID[row][k], '#FFFF4D');
 				}
+				this.unhighlight(6, 0);
 				this.cmd(act.step);
 			}
+			this.highlight(12, 0);
+			this.cmd(act.step);
+			this.unhighlight(12, 0);
+			this.highlight(13, 0);
+			this.cmd(act.step);
+			this.unhighlight(13, 0);
 			if (i < text.length - pattern.length) {
+				this.highlight(14, 0);
 				textHash =
 					this.baseValue * (textHash - base * (text.charCodeAt(i) - 97)) +
 					(text.charCodeAt(i + pattern.length) - 97);
@@ -377,9 +435,12 @@ export default class RabinKarp extends Algorithm {
 				textCalculation =
 					textCalculation.substring(0, textCalculation.length - 2) + ' = ' + textHash;
 				this.cmd(act.setText, this.textHashCalculationID, textCalculation);
+				this.cmd(act.step);
+				this.unhighlight(14, 0);
 			}
 			row++;
 		}
+		this.unhighlight(5, 0);
 
 		return this.commands;
 	}
@@ -406,6 +467,8 @@ export default class RabinKarp extends Algorithm {
 		this.comparisonMatrixID = [];
 		this.compCount = 0;
 		this.cmd(act.setText, this.comparisonCountID, '');
+		this.removeCode(this.codeID);
+		this.codeID = [];
 
 		return this.commands;
 	}


### PR DESCRIPTION
Adds pseudocode for Boyer Moore (including the Galil Rule), KMP, Rabin Karp and Brute Force.

For each of them, the pseudocode isn't generated until the algorithm starts (because the pattern space is variable). Code for the BM last occurrence table and KMP failure table are also included, and disappear after preprocessing is finished. 