### PR TITLE
Make SkipLists random again!

### DIFF
--- a/src/algo/SkipList.js
+++ b/src/algo/SkipList.js
@@ -272,7 +272,7 @@ export default class SkipList extends Algorithm {
 		this.commands = [];
 
 		if (heads === undefined) {
-			heads = Math.floor(Math.random() * (this.size + 1));
+			heads = Math.floor(Math.random() * 5); // random int between [0, 4]
 		}
 		heads = Math.min(heads, 4);
 


### PR DESCRIPTION
This is a simple fix that truly randomizes skip lists. The previous calculation was dependent on the size of the skiplist. So the very first time a user called add with random heads, it will always give you 0 heads. This is now fixed