### PR TITLE
Add negative number sorting capability to radix sort

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-ga4": "^2.0.0",
-				"react-hook-theme": "^1.2.5",
+				"react-hook-theme": "^1.2.6",
 				"react-icons": "^4.7.1",
 				"react-router-dom": "^5.1.2",
 				"react-scripts": "5.0.1"
@@ -13552,9 +13552,9 @@
 			"integrity": "sha512-WHi98hMunzh4ngRdNil8NN6Qly3ZZUkprhbgSqA+NFzovp8zqpYV3jcbKL9FnMdeBQHGhv8AVNCT2oFEE+EFXA=="
 		},
 		"node_modules/react-hook-theme": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/react-hook-theme/-/react-hook-theme-1.2.5.tgz",
-			"integrity": "sha512-eUL1CXKlmhMwa3p59qyfHmaxsKkgXthHRgq1EQ+uxU9X4rvgGNzpNqsM49F44YFfnw4wXMAip0Z5ymRS35rWSA==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/react-hook-theme/-/react-hook-theme-1.2.6.tgz",
+			"integrity": "sha512-gM16oqCgTXTSUfravEvq9kfxzjZIDkC+sJVnFTI2JijTcaG9H/n3nirDcL52gRK9WQfW32dJOs0v4CYFp2hhhg==",
 			"peerDependencies": {
 				"react": ">=16.8.0",
 				"react-dom": ">=16.8.0"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-ga4": "^2.0.0",
-		"react-hook-theme": "^1.2.5",
+		"react-hook-theme": "^1.2.6",
 		"react-icons": "^4.7.1",
 		"react-router-dom": "^5.1.2",
 		"react-scripts": "5.0.1"

--- a/src/algo/Algorithm.js
+++ b/src/algo/Algorithm.js
@@ -372,13 +372,13 @@ export default class Algorithm {
 
 export function controlKey(keyASCII) {
 	return (
-		keyASCII === 8 ||
-		keyASCII === 9 ||
-		keyASCII === 37 ||
-		keyASCII === 38 ||
-		keyASCII === 39 ||
-		keyASCII === 40 ||
-		keyASCII === 46
+		keyASCII === 8 ||  // backspace
+		keyASCII === 9 ||  // tab
+		keyASCII === 37 || // % percent 
+		keyASCII === 38 || // & ampersand
+		keyASCII === 39 || // ' apostrophe
+		keyASCII === 40 || // ( left parenthesis
+		keyASCII === 46    // . period
 	);
 }
 

--- a/src/algo/Algorithm.js
+++ b/src/algo/Algorithm.js
@@ -335,8 +335,8 @@ export default class Algorithm {
 			} else if (
 				keyASCII === 190 ||
 				keyASCII === 59 ||
-				keyASCII === 173 ||
-				keyASCII === 189
+				keyASCII === 173
+				// keyASCII === 189
 			) {
 				return false;
 			} else if (

--- a/src/algo/LSDRadix.js
+++ b/src/algo/LSDRadix.js
@@ -38,14 +38,14 @@ const MAX_ARRAY_SIZE = 18;
 const INFO_LABEL_X = 75;
 const INFO_LABEL_Y = 20;
 
-const ARRAY_START_X = 525;
+const ARRAY_START_X = 475;
 const ARRAY_START_Y = 70;
 
 const ARRAY_ELEM_WIDTH = 50;
 const ARRAY_ELEM_HEIGHT = 50;
 
-const BUCKETS_START_X = 525;
-const NEGATIVE_BUCKETS_START_X = 975;
+const BUCKETS_START_X = 475;
+const NEGATIVE_BUCKETS_START_X = 925;
 const BUCKETS_START_Y = 140;
 
 const BUCKET_ELEM_WIDTH = 50;
@@ -55,7 +55,7 @@ const BUCKET_ELEM_SPACING = 15;
 const CODE_START_X = 50;
 const CODE_START_Y = 100;
 
-const MAX_VALUE = 9999999;
+const MAX_VALUE = 999999;
 
 let negativeNumbersEnabled = false;
 
@@ -73,7 +73,7 @@ export default class LSDRadix extends Algorithm {
 		const verticalGroup = addGroupToAlgorithmBar(false);
 
 		addLabelToAlgorithmBar(
-			'Comma seperated list (e.g. "3,1,2"). Max 18 elements & no elements > 7 digits.',
+			'Comma seperated list (e.g. "3,1,2"). Max 18 elements & no elements > 6 digits.',
 			verticalGroup,
 		);
 
@@ -327,17 +327,19 @@ export default class LSDRadix extends Algorithm {
 		this.cmd(
 			act.createHighlightCircle,
 			this.iPointerID,
-			'#FF0000',
+			'#FF0000', // red circle
 			ARRAY_START_X,
 			ARRAY_START_Y,
+			21.5
 		);
 		this.cmd(act.setHighlight, this.iPointerID, 1);
 		this.cmd(
 			act.createHighlightCircle,
 			this.jPointerID,
-			'#0000FF',
+			'#0000FF', // blue circle
 			ARRAY_START_X + ARRAY_ELEM_WIDTH,
 			ARRAY_START_Y,
+			21.5
 		);
 		this.cmd(act.setHighlight, this.jPointerID, 1);
 
@@ -380,6 +382,7 @@ export default class LSDRadix extends Algorithm {
 				'#0000FF',
 				ARRAY_START_X,
 				ARRAY_START_Y,
+				21.5
 			);
 			this.cmd(act.setHighlight, this.iPointerID, 1);
 			this.cmd(act.step);

--- a/src/algo/LSDRadix.js
+++ b/src/algo/LSDRadix.js
@@ -122,7 +122,7 @@ export default class LSDRadix extends Algorithm {
 		this.code = [
 			['procedure LSDRadixSort(array):'],
 			['     buckets <- array of 10 lists'],
-			['     iterations <- length of longest number'],
+			['     iterations <- length of largest number by magnitude'],
 			['     length <- length of array'],
 			['     for i <- 1, iterations do'],
 			['          for j <- 0, length - 1 do'],
@@ -187,7 +187,6 @@ export default class LSDRadix extends Algorithm {
 		negativeNumbersEnabled = !negativeNumbersEnabled;
 		this.implementAction(this.clear.bind(this));
 		if (negativeNumbersEnabled) {
-			console.log(negativeNumbersEnabled);
 			this.cmd(act.setText, this.codeID[1][0], '     buckets <- array of 19 lists');
 			this.cmd(act.setText, this.codeID[10][0], '          for bucket <- -9, 9 do');
 		} else {
@@ -223,12 +222,10 @@ export default class LSDRadix extends Algorithm {
 		this.commands = [];
 
 		this.arrayID = [];
-		console.log(params);
 		this.arrayData = params
     		.map(x => parseInt(x, 10))
     		.filter(x => !Number.isNaN(x))
     		.slice(0, MAX_ARRAY_SIZE);
-		console.log(this.arrayData);
 		const length = this.arrayData.length;
 		const elemCounts = new Map();
 		const letterMap = new Map();
@@ -372,7 +369,7 @@ export default class LSDRadix extends Algorithm {
 
 		// Run algorithm
 		for (let i = 0; i < digits; i++) {
-			this.cmd(act.setText, this.infoLabelID, 'Getting digits at position ' + (i + 1));
+			this.cmd(act.setText, this.infoLabelID, 'Getting digits at index ' + i);
 			this.cmd(
 				act.createHighlightCircle,
 				this.iPointerID,
@@ -401,19 +398,33 @@ export default class LSDRadix extends Algorithm {
 				const data = this.arrayData[j];
 				const display = this.arrayDisplay[j];
 				const digit = this.nthDigit(data, i);
+				console.log(digit)
 				this.bucketsID[digit].push(id);
 				this.bucketsData[digit].push(data);
 				this.bucketsDisplay[digit].push(display);
 				const len = this.bucketsData[digit].length;
-				this.cmd(
-					act.createRectangle,
-					id,
-					display,
-					BUCKET_ELEM_WIDTH,
-					BUCKET_ELEM_HEIGHT,
-					BUCKETS_START_X + digit * BUCKET_ELEM_WIDTH,
-					BUCKETS_START_Y + len * BUCKET_ELEM_HEIGHT + len * BUCKET_ELEM_SPACING,
-				);
+
+				if (negativeNumbersEnabled) {
+					this.cmd(
+						act.createRectangle,
+						id,
+						display,
+						BUCKET_ELEM_WIDTH,
+						BUCKET_ELEM_HEIGHT,
+						NEGATIVE_BUCKETS_START_X + digit * BUCKET_ELEM_WIDTH,
+						BUCKETS_START_Y + len * BUCKET_ELEM_HEIGHT + len * BUCKET_ELEM_SPACING,
+					);
+				} else {
+					this.cmd(
+						act.createRectangle,
+						id,
+						display,
+						BUCKET_ELEM_WIDTH,
+						BUCKET_ELEM_HEIGHT,
+						BUCKETS_START_X + digit * BUCKET_ELEM_WIDTH,
+						BUCKETS_START_Y + len * BUCKET_ELEM_HEIGHT + len * BUCKET_ELEM_SPACING,
+					);
+				}
 				this.cmd(
 					act.connect,
 					this.bucketsID[digit][this.bucketsID[digit].length - 2],
@@ -434,57 +445,112 @@ export default class LSDRadix extends Algorithm {
 			this.highlight(10, 0);
 			let index = 0;
 			this.cmd(act.step);
-			for (let j = 0; j < 10; j++) {
-				this.unhighlight(10, 0);
-				const idBucket = this.bucketsID[j];
-				const dataBucket = this.bucketsData[j];
-				const displayBucket = this.bucketsDisplay[j];
-				this.highlight(11, 0);
-				while (dataBucket.length) {
-					this.cmd(act.step);
-					this.unhighlight(11, 0);
-					this.highlight(12, 0);
-					const labelID = this.nextIndex++;
-					const nodeID = idBucket.splice(1, 1)[0];
-					const data = dataBucket.shift();
-					const display = displayBucket.shift();
-					this.cmd(
-						act.createLabel,
-						labelID,
-						display,
-						BUCKETS_START_X + j * BUCKET_ELEM_WIDTH,
-						BUCKETS_START_Y + BUCKET_ELEM_HEIGHT + BUCKET_ELEM_SPACING,
-					);
-					this.cmd(
-						act.move,
-						labelID,
-						ARRAY_START_X + index * ARRAY_ELEM_WIDTH,
-						ARRAY_START_Y,
-					);
-					this.cmd(act.step);
-					this.cmd(act.setText, this.arrayID[index], display);
-					this.cmd(act.delete, labelID);
-					this.cmd(act.delete, nodeID);
-					this.unhighlight(12, 0);
-					this.highlight(13, 0);
-					if (dataBucket.length) {
-						this.cmd(act.connect, idBucket[0], idBucket[1]);
-						for (let k = 1; k < idBucket.length; k++) {
-							this.cmd(
-								act.move,
-								idBucket[k],
-								BUCKETS_START_X + j * BUCKET_ELEM_WIDTH,
-								BUCKETS_START_Y + k * BUCKET_ELEM_HEIGHT + k * BUCKET_ELEM_SPACING,
-							);
+			if (negativeNumbersEnabled) {
+				for (let j = -9; j < 10; j++) {
+					this.unhighlight(10, 0);
+					const idBucket = this.bucketsID[j];
+					const dataBucket = this.bucketsData[j];
+					const displayBucket = this.bucketsDisplay[j];
+					this.highlight(11, 0);
+					while (dataBucket.length) {
+						this.cmd(act.step);
+						this.unhighlight(11, 0);
+						this.highlight(12, 0);
+						const labelID = this.nextIndex++;
+						const nodeID = idBucket.splice(1, 1)[0];
+						const data = dataBucket.shift();
+						const display = displayBucket.shift();
+						this.cmd(
+							act.createLabel,
+							labelID,
+							display,
+							NEGATIVE_BUCKETS_START_X + j * BUCKET_ELEM_WIDTH,
+							BUCKETS_START_Y + BUCKET_ELEM_HEIGHT + BUCKET_ELEM_SPACING,
+						);
+						this.cmd(
+							act.move,
+							labelID,
+							ARRAY_START_X + index * ARRAY_ELEM_WIDTH,
+							ARRAY_START_Y,
+						);
+						this.cmd(act.step);
+						this.cmd(act.setText, this.arrayID[index], display);
+						this.cmd(act.delete, labelID);
+						this.cmd(act.delete, nodeID);
+						this.unhighlight(12, 0);
+						this.highlight(13, 0);
+						if (dataBucket.length) {
+							this.cmd(act.connect, idBucket[0], idBucket[1]);
+							for (let k = 1; k < idBucket.length; k++) {
+								this.cmd(
+									act.move,
+									idBucket[k],
+									NEGATIVE_BUCKETS_START_X + j * BUCKET_ELEM_WIDTH,
+									BUCKETS_START_Y + k * BUCKET_ELEM_HEIGHT + k * BUCKET_ELEM_SPACING,
+								);
+							}
 						}
+						this.cmd(act.step);
+						this.arrayData[index] = data;
+						this.arrayDisplay[index] = display;
+						index++;
+						this.unhighlight(13, 0);
 					}
-					this.cmd(act.step);
-					this.arrayData[index] = data;
-					this.arrayDisplay[index] = display;
-					index++;
-					this.unhighlight(13, 0);
+					this.unhighlight(11, 0);
 				}
-				this.unhighlight(11, 0);
+			} else {
+				for (let j = 0; j < 10; j++) {
+					this.unhighlight(10, 0);
+					const idBucket = this.bucketsID[j];
+					const dataBucket = this.bucketsData[j];
+					const displayBucket = this.bucketsDisplay[j];
+					this.highlight(11, 0);
+					while (dataBucket.length) {
+						this.cmd(act.step);
+						this.unhighlight(11, 0);
+						this.highlight(12, 0);
+						const labelID = this.nextIndex++;
+						const nodeID = idBucket.splice(1, 1)[0];
+						const data = dataBucket.shift();
+						const display = displayBucket.shift();
+						this.cmd(
+							act.createLabel,
+							labelID,
+							display,
+							BUCKETS_START_X + j * BUCKET_ELEM_WIDTH,
+							BUCKETS_START_Y + BUCKET_ELEM_HEIGHT + BUCKET_ELEM_SPACING,
+						);
+						this.cmd(
+							act.move,
+							labelID,
+							ARRAY_START_X + index * ARRAY_ELEM_WIDTH,
+							ARRAY_START_Y,
+						);
+						this.cmd(act.step);
+						this.cmd(act.setText, this.arrayID[index], display);
+						this.cmd(act.delete, labelID);
+						this.cmd(act.delete, nodeID);
+						this.unhighlight(12, 0);
+						this.highlight(13, 0);
+						if (dataBucket.length) {
+							this.cmd(act.connect, idBucket[0], idBucket[1]);
+							for (let k = 1; k < idBucket.length; k++) {
+								this.cmd(
+									act.move,
+									idBucket[k],
+									BUCKETS_START_X + j * BUCKET_ELEM_WIDTH,
+									BUCKETS_START_Y + k * BUCKET_ELEM_HEIGHT + k * BUCKET_ELEM_SPACING,
+								);
+							}
+						}
+						this.cmd(act.step);
+						this.arrayData[index] = data;
+						this.arrayDisplay[index] = display;
+						index++;
+						this.unhighlight(13, 0);
+					}
+					this.unhighlight(11, 0);
+				}
 			}
 		}
 
@@ -532,10 +598,16 @@ export default class LSDRadix extends Algorithm {
 	}
 
 	nthDigit(data, digit) {
+		const sign = Math.sign(data);
+		data = Math.abs(data);
 		data = Math.floor(data / Math.pow(10, digit));
 		data %= 10;
+		if (sign === -1) {
+		  data *= -1;
+		}
+		console.log(data);
 		return data;
-	}
+	  }
 
 	disableUI() {
 		for (let i = 0; i < this.controls.length; i++) {

--- a/src/algo/LSDRadix.js
+++ b/src/algo/LSDRadix.js
@@ -373,7 +373,7 @@ export default class LSDRadix extends Algorithm {
 
 		// Run algorithm
 		for (let i = 0; i < digits; i++) {
-			this.cmd(act.setText, this.infoLabelID, 'Getting digits at index ' + i);
+			this.cmd(act.setText, this.infoLabelID, 'Getting digits at index ' + i + ' (0-aligned)');
 			this.cmd(
 				act.createHighlightCircle,
 				this.iPointerID,

--- a/src/algo/LSDRadix.js
+++ b/src/algo/LSDRadix.js
@@ -222,7 +222,6 @@ export default class LSDRadix extends Algorithm {
 	}
 
 	sort(params) {
-		// params is list of numbers
 		this.highlight(0, 0);
 		this.commands = [];
 
@@ -327,7 +326,7 @@ export default class LSDRadix extends Algorithm {
 		this.cmd(
 			act.createHighlightCircle,
 			this.iPointerID,
-			'#FF0000', // red circle
+			'#FF0000',
 			ARRAY_START_X,
 			ARRAY_START_Y,
 			21.5
@@ -336,7 +335,7 @@ export default class LSDRadix extends Algorithm {
 		this.cmd(
 			act.createHighlightCircle,
 			this.jPointerID,
-			'#0000FF', // blue circle
+			'#0000FF',
 			ARRAY_START_X + ARRAY_ELEM_WIDTH,
 			ARRAY_START_Y,
 			21.5

--- a/src/algo/LSDRadix.js
+++ b/src/algo/LSDRadix.js
@@ -25,6 +25,7 @@
 // or implied, of the University of San Francisco
 
 import Algorithm, {
+	addCheckboxToAlgorithmBar,
 	addControlToAlgorithmBar,
 	addDivisorToAlgorithmBar,
 	addGroupToAlgorithmBar,
@@ -50,8 +51,10 @@ const BUCKET_ELEM_WIDTH = 50;
 const BUCKET_ELEM_HEIGHT = 20;
 const BUCKET_ELEM_SPACING = 15;
 
-const CODE_START_X = 650;
-const CODE_START_Y = 140;
+const CODE_START_X = 50;
+const CODE_START_Y = 100;
+
+let negativeNumbersEnabled = false;
 
 export default class LSDRadix extends Algorithm {
 	constructor(am, w, h) {
@@ -94,6 +97,13 @@ export default class LSDRadix extends Algorithm {
 		this.clearButton = addControlToAlgorithmBar('Button', 'Clear');
 		this.clearButton.onclick = this.clearCallback.bind(this);
 		this.controls.push(this.clearButton);
+
+		addDivisorToAlgorithmBar();
+
+		// Option to sort negative numbers
+		this.negativeNumbersCheckbox = addCheckboxToAlgorithmBar('Sort negative numbers', false);
+		this.negativeNumbersCheckbox.onclick = this.toggleNegativeNumbers.bind(this);
+		this.controls.push(this.negativeNumbersCheckbox);
 	}
 
 	setup() {
@@ -110,7 +120,7 @@ export default class LSDRadix extends Algorithm {
 
 		this.code = [
 			['procedure LSDRadixSort(array):'],
-			['     buckets <- list of 10 lists'],
+			['     buckets <- array of 10 lists'],
 			['     iterations <- length of longest number'],
 			['     length <- length of array'],
 			['     for i <- 1, iterations do'],
@@ -149,6 +159,10 @@ export default class LSDRadix extends Algorithm {
 		this.jPointerID = this.nextIndex++;
 		this.infoLabelID = this.nextIndex++;
 		this.codeID = this.addCodeToCanvasBase(this.code, CODE_START_X, CODE_START_Y);
+		if (negativeNumbersEnabled) {
+			this.cmd(act.setText, this.codeID[1][0], '     buckets <- array of 19 lists');
+			this.cmd(act.setText, this.codeID[10][0], '          for bucket <- -9, 9 do');
+		}
 	}
 
 	sortCallback() {
@@ -166,6 +180,19 @@ export default class LSDRadix extends Algorithm {
 
 	clearCallback() {
 		this.implementAction(this.clear.bind(this));
+	}
+
+	toggleNegativeNumbers() {
+		negativeNumbersEnabled = !negativeNumbersEnabled;
+		this.implementAction(this.clear.bind(this));
+		if (negativeNumbersEnabled) {
+			console.log(negativeNumbersEnabled);
+			this.cmd(act.setText, this.codeID[1][0], '     buckets <- array of 19 lists');
+			this.cmd(act.setText, this.codeID[10][0], '          for bucket <- -9, 9 do');
+		} else {
+			this.cmd(act.setText, this.codeID[1][0], '     buckets <- array of 10 lists');
+			this.cmd(act.setText, this.codeID[10][0], '          for bucket <- 0, 9 do');
+		}
 	}
 
 	clear() {

--- a/src/anim/AnimationMain.js
+++ b/src/anim/AnimationMain.js
@@ -304,7 +304,7 @@ export default class AnimationManager extends EventListener {
 		canvas.height = height;
 
 		tableEntry = document.createElement('td');
-		txtNode = document.createTextNode('h:');
+		txtNode = document.createTextNode('Canvas height:');
 		tableEntry.appendChild(txtNode);
 		controlBar.appendChild(tableEntry);
 

--- a/src/examples/ExampleModals.js
+++ b/src/examples/ExampleModals.js
@@ -206,6 +206,16 @@ export default {
 			</li>
 		</ul>
 	),
+	LSDRadix: (
+		<ul>
+			<li>
+				The range of sortable numbers for this visualization is [-99999, 999999]. Any numbers outside this range will not be sorted.
+			</li>
+			<li>
+				When sorting negative numbers, a larger buckets array with indices -9 to 9 is needed.
+			</li>
+		</ul>
+	),
 	SkipList: (
 		<ul>
 			<li>


### PR DESCRIPTION
This addresses issues #138 and #139. Users now have the option to sort negative numbers by a checkbox selection. The maximum value has been capped to 6 characters making [-99999, 999999] the range of sortable numbers. Capping $k$ at 6 keeps the input array reasonably sized while still demonstrating the importance of $k$ in radix sort. 