### PR TITLE
Hashmap fixes

### DIFF
--- a/src/algo/ClosedHash.js
+++ b/src/algo/ClosedHash.js
@@ -43,7 +43,7 @@ const LINKED_ITEM_HEIGHT = 20;
 const LINKED_ITEM_INITIAL_X = 60;
 const LINKED_ITEM_INITIAL_Y = 40;
 const LINKED_ITEM_X_DELTA_INIT = 85;
-const LINKED_ITEM_X_DELTA = 100;
+const LINKED_ITEM_X_DELTA = 130;
 
 const EXPLAIN_LABEL_X = 550;
 const EXPLAIN_LABEL_Y = 15;
@@ -264,7 +264,7 @@ export default class ClosedHash extends Hash {
 			while (tmp != null && !found) {
 				this.cmd(act.setHighlight, tmp.graphicID, 1);
 				if (tmp.key === key) {
-					this.cmd(act.setText, compareIndex, tmp.key + '==' + key);
+					this.cmd(act.setText, compareIndex, tmp.key + ' == ' + key);
 					old = tmp;
 					found = true;
 					this.cmd(act.step);

--- a/src/algo/Hash.js
+++ b/src/algo/Hash.js
@@ -674,7 +674,7 @@ export default class Hash extends Algorithm {
 	}
 
 	insertCallback() {
-		const insertedKey = this.keyField.value;
+		const insertedKey = this.hashType === 'integers' ? parseInt(this.keyField.value).toString() : this.keyField.value;
 		const insertedValue = this.valueField.value;
 		if (insertedKey !== '' && insertedValue !== '') {
 			this.keyField.value = '';


### PR DESCRIPTION
This addresses two bugs in HashMaps. In closed addressing, colliding entries will clump together. Also keys with leading zeros were interpreted as distinct when hashing integers. That is "9" and "09" were treated as different keys when they are effectively the same integer key. These are now fixed.