### PR TITLE
Add Pseudocode Toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 # my notes for how to contribute from the bluejeans meeting
 contrib.txt
 .eslintrc
+
+# ide settings
+.vscode/

--- a/src/algo/Algorithm.js
+++ b/src/algo/Algorithm.js
@@ -216,7 +216,7 @@ export default class Algorithm {
 		line_height = typeof line_height !== 'undefined' ? line_height : CODE_LINE_HEIGHT;
 		standard_color =
 			typeof standard_color !== 'undefined' ? standard_color : CODE_STANDARD_COLOR;
-		layer = typeof layer !== 'undefined' ? layer : 0;
+		layer = typeof layer !== 'undefined' ? layer : 32;
 		const isCode = true;
 		const codeID = Array(code.length);
 		let i, j;

--- a/src/algo/ArrayList.js
+++ b/src/algo/ArrayList.js
@@ -83,7 +83,7 @@ export default class ArrayList extends Algorithm {
 			this.addValueField,
 			() => this.addIndexCallback(),
 			4,
-			true
+			true,
 		);
 		this.controls.push(this.addValueField);
 

--- a/src/algo/DFS.js
+++ b/src/algo/DFS.js
@@ -186,23 +186,9 @@ export default class DFS extends Graph {
 		];
 
 		if (this.physicalStack) {
-			this.codeID = this.addCodeToCanvasBase(
-				this.itCode,
-				CODE_START_X,
-				CODE_START_Y,
-				undefined,
-				undefined,
-				1,
-			);
+			this.codeID = this.addCodeToCanvasBase(this.itCode, CODE_START_X, CODE_START_Y);
 		} else {
-			this.codeID = this.addCodeToCanvasBase(
-				this.recCode,
-				CODE_START_X,
-				CODE_START_Y,
-				undefined,
-				undefined,
-				1,
-			);
+			this.codeID = this.addCodeToCanvasBase(this.recCode, CODE_START_X, CODE_START_Y);
 		}
 
 		this.animationManager.setAllLayers([0, this.currentLayer]);

--- a/src/algo/DequeArray.js
+++ b/src/algo/DequeArray.js
@@ -386,11 +386,7 @@ export default class DequeArray extends Algorithm {
 	addLast(elemToAddLast) {
 		this.commands = [];
 
-		this.addLastCodeID = this.addCodeToCanvasBase(
-			this.addLastCode,
-			CODE_START_X,
-			CODE_START_Y,
-		);
+		this.addLastCodeID = this.addCodeToCanvasBase(this.addLastCode, CODE_START_X, CODE_START_Y);
 
 		const labAddLastID = this.nextIndex++;
 		const labAddLastValID = this.nextIndex++;
@@ -447,7 +443,7 @@ export default class DequeArray extends Algorithm {
 
 		this.nextIndex = this.nextIndex - 2;
 
-		this.removeCode(this.addLastCodeID)
+		this.removeCode(this.addLastCodeID);
 
 		return this.commands;
 	}
@@ -552,7 +548,7 @@ export default class DequeArray extends Algorithm {
 
 		this.nextIndex = this.nextIndex - 2;
 
-		this.removeCode(this.addFirstCodeID)
+		this.removeCode(this.addFirstCodeID);
 
 		return this.commands;
 	}
@@ -656,7 +652,7 @@ export default class DequeArray extends Algorithm {
 		this.unhighlight(0, 0, this.removeFirstCodeID);
 		this.nextIndex = this.nextIndex - 2;
 
-		this.removeCode(this.removeFirstCodeID)
+		this.removeCode(this.removeFirstCodeID);
 
 		return this.commands;
 	}
@@ -736,7 +732,7 @@ export default class DequeArray extends Algorithm {
 		this.size--;
 		this.nextIndex = this.nextIndex - 2;
 
-		this.removeCode(this.removeLastCodeID)
+		this.removeCode(this.removeLastCodeID);
 
 		return this.commands;
 	}

--- a/src/algo/Dijkstras.js
+++ b/src/algo/Dijkstras.js
@@ -126,14 +126,7 @@ export default class Dijkstras extends Graph {
 			['      PQ.enqueue((w, d1 + d2))'],
 		];
 
-		this.codeID = this.addCodeToCanvasBase(
-			this.code,
-			CODE_START_X,
-			CODE_START_Y,
-			undefined,
-			undefined,
-			1,
-		);
+		this.codeID = this.addCodeToCanvasBase(this.code, CODE_START_X, CODE_START_Y);
 
 		this.tableEntryHeight = this.isLarge ? LARGE_TABLE_ENTRY_HEIGHT : SMALL_TABLE_ENTRY_HEIGHT;
 		for (let i = 0; i < this.size; i++) {

--- a/src/algo/DoublyLinkedList.js
+++ b/src/algo/DoublyLinkedList.js
@@ -578,7 +578,6 @@ export default class DoublyLinkedList extends Algorithm {
 			CODE_START_Y,
 		);
 
-
 		if (isAddFront) {
 			this.highlight(0, 0, this.addFrontCodeID);
 		} else if (isAddBack) {
@@ -1079,9 +1078,9 @@ export default class DoublyLinkedList extends Algorithm {
 			this.unhighlight(17, 0, this.removeIndexCodeID);
 		}
 
-			this.removeCode(this.removeFrontCodeID);
-			this.removeCode(this.removeBackCodeID);
-			this.removeCode(this.removeIndexCodeID);
+		this.removeCode(this.removeFrontCodeID);
+		this.removeCode(this.removeBackCodeID);
+		this.removeCode(this.removeIndexCodeID);
 
 		return this.commands;
 	}

--- a/src/algo/Hash.js
+++ b/src/algo/Hash.js
@@ -170,9 +170,14 @@ export default class Hash extends Algorithm {
 			'Restart',
 			this.rightVerticalBottom,
 		);
-		this.initialCapacityField.onkeydown = this.returnSubmit(this.initialCapacityField, null, 2, true);
+		this.initialCapacityField.onkeydown = this.returnSubmit(
+			this.initialCapacityField,
+			null,
+			2,
+			true,
+		);
 		this.restartButton.onclick = this.clearCallback.bind(this);
-		
+
 		addDivisorToAlgorithmBar();
 
 		this.dropDownParentGroup = addGroupToAlgorithmBar(false);

--- a/src/algo/Kruskals.js
+++ b/src/algo/Kruskals.js
@@ -166,14 +166,7 @@ export default class Kruskals extends Graph {
 			[`    merge u's cluster with v's cluster`],
 		];
 
-		this.codeID = this.addCodeToCanvasBase(
-			this.code,
-			CODE_START_X,
-			CODE_START_Y,
-			undefined,
-			undefined,
-			1,
-		);
+		this.codeID = this.addCodeToCanvasBase(this.code, CODE_START_X, CODE_START_Y);
 
 		this.animationManager.setAllLayers([0, this.currentLayer]);
 		this.animationManager.startNewAnimation(this.commands);

--- a/src/algo/QueueArray.js
+++ b/src/algo/QueueArray.js
@@ -89,7 +89,7 @@ export default class QueueArray extends Algorithm {
 			this.enqueueField,
 			this.enqueueCallback.bind(this),
 			4,
-			true
+			true,
 		);
 
 		this.enqueueButton = addControlToAlgorithmBar('Button', 'Enqueue');

--- a/src/algo/QueueLL.js
+++ b/src/algo/QueueLL.js
@@ -80,7 +80,7 @@ export default class QueueLL extends Algorithm {
 			this.enqueueField,
 			this.enqueueCallback.bind(this),
 			4,
-			true
+			true,
 		);
 
 		this.enqueueButton = addControlToAlgorithmBar('Button', 'Enqueue');

--- a/src/algo/StackArray.js
+++ b/src/algo/StackArray.js
@@ -72,7 +72,7 @@ export default class StackArray extends Algorithm {
 			this.pushField,
 			this.pushCallback.bind(this),
 			4,
-			true
+			true,
 		);
 
 		this.pushButton = addControlToAlgorithmBar('Button', 'Push');

--- a/src/algo/StackLL.js
+++ b/src/algo/StackLL.js
@@ -75,7 +75,7 @@ export default class StackLL extends Algorithm {
 			this.pushField,
 			this.pushCallback.bind(this),
 			4,
-			true
+			true,
 		);
 
 		this.pushButton = addControlToAlgorithmBar('Button', 'Push');

--- a/src/anim/AnimationMain.js
+++ b/src/anim/AnimationMain.js
@@ -661,6 +661,12 @@ export default class AnimationManager extends EventListener {
 		this.animatedObjects.draw();
 	}
 
+	toggleLayer(layer) {
+		this.animatedObjects.toggleLayer(layer);
+		console.log(layer);
+		this.animatedObjects.draw();
+	}
+
 	setAllLayers(layers) {
 		this.animatedObjects.setAllLayers(layers);
 		// Drop in an extra draw call here, just in case we are not

--- a/src/anim/ObjectManager.js
+++ b/src/anim/ObjectManager.js
@@ -53,6 +53,7 @@ export default class ObjectManager {
 		this.backEdges = [];
 		this.activeLayers = [];
 		this.activeLayers[0] = true;
+		this.activeLayers[32] = true; // pseudocode layer
 		this.ctx = canvasRef.current.getContext('2d');
 		this.framenum = 0;
 		this.width = 0;

--- a/src/anim/ObjectManager.js
+++ b/src/anim/ObjectManager.js
@@ -209,6 +209,12 @@ export default class ObjectManager {
 		this.resetLayers();
 	}
 
+	toggleLayer(layer) {
+		this.activeLayers[layer] = !this.activeLayers[layer];
+		console.log(this.activeLayers);
+		this.resetLayers();
+	}
+
 	resetLayers() {
 		let i;
 		for (i = 0; i < this.nodes.length; i++) {

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -46,7 +46,12 @@ class Header extends React.Component {
 									className="rotate-effect"
 								/>
 							) : (
-								<BsMoonFill size={29} onClick={toggleTheme} color="#d4f1f1" />
+								<BsMoonFill
+									size={29}
+									onClick={toggleTheme}
+									color="#d4f1f1"
+									className="rotate-effect"
+								/>
 							)}
 						</div>
 					</div>

--- a/src/css/AlgoScreen.css
+++ b/src/css/AlgoScreen.css
@@ -61,6 +61,12 @@
 	align-items: center;
 	border-bottom: var(--border) 2px solid;
 	transition: all 0.4s ease 0s;
+	padding: 5px 5px;
+}
+
+.VisualizationMainPage #toggles * {
+	margin: 0 10px;
+	color: var(--primary);
 }
 
 .VisualizationMainPage #AlgorithmSpecificControls {
@@ -177,6 +183,9 @@ em {
 	filter: var(--filter);
 }
 
+.pseudocode-toggle {
+	cursor: pointer;
+}
 .VisualizationMainPage .modal {
 	position: absolute;
 	right: 20px;

--- a/src/screens/AlgoScreen.js
+++ b/src/screens/AlgoScreen.js
@@ -1,6 +1,6 @@
 import '../css/AlgoScreen.css';
 import '../css/App.css';
-import { BsFileEarmarkCodeFill, BsFillSunFill, BsMoonFill } from 'react-icons/bs';
+import { BsBookHalf, BsFileEarmarkCodeFill, BsFillSunFill, BsMoonFill } from 'react-icons/bs';
 import AnimationManager from '../anim/AnimationMain';
 import Footer from '../components/Footer';
 import Header from '../components/Header';
@@ -26,6 +26,7 @@ class AlgoScreen extends React.Component {
 			examplesEnabled: false,
 			width: 0,
 			theme: 'light',
+			pseudocodeEnabled: false,
 		};
 		ReactGA.send({ hitType: 'pageview', page: algoName });
 	}
@@ -98,9 +99,15 @@ class AlgoScreen extends React.Component {
 										size={31}
 										onClick={toggleTheme}
 										color="#f9c333"
+										className="rotate-effect"
 									/>
 								) : (
-									<BsMoonFill size={29} onClick={toggleTheme} color="#d4f1f1" />
+									<BsMoonFill
+										size={29}
+										onClick={toggleTheme}
+										color="#d4f1f1"
+										className="rotate-effect"
+									/>
 								)}
 							</div>
 						</h1>
@@ -109,17 +116,23 @@ class AlgoScreen extends React.Component {
 					<div id="mainContent">
 						<div id="algoControlSection">
 							<table id="AlgorithmSpecificControls"></table>
-							{modals[algoName] && (
-								<IconContext.Provider value={{ className: 'menu-modal' }}>
-									<MdMenuBook onClick={this.toggleExamples} />
-								</IconContext.Provider>
-							)}
-							<div id="pseudocodeToggle">
-								<BsFileEarmarkCodeFill
-									size={31}
-									onClick={this.togglePseudocode}
-									color="black"
-								/>
+							<div id="toggles">
+								{algoMap[algoName][2] && (
+									<BsFileEarmarkCodeFill
+										className="pseudocode-toggle"
+										size={32}
+										onClick={this.togglePseudocode}
+										opacity={this.state.pseudocodeEnabled ? '100%' : '40%'}
+									/>
+								)}
+								{modals[algoName] && (
+									<BsBookHalf
+										className="menu-modal"
+										size={30}
+										onClick={this.toggleExamples}
+										opacity={this.state.examplesEnabled ? '100%' : '40%'}
+									/>
+								)}
 							</div>
 						</div>
 
@@ -154,7 +167,10 @@ class AlgoScreen extends React.Component {
 
 	toggleExamples = () => this.setState(state => ({ examplesEnabled: !state.examplesEnabled }));
 
-	togglePseudocode = () => this.animManag.toggleLayer(32);
+	togglePseudocode = () => {
+		this.setState(state => ({ pseudocodeEnabled: !state.pseudocodeEnabled }));
+		this.animManag.toggleLayer(32);
+	};
 }
 
 AlgoScreen.propTypes = {

--- a/src/screens/AlgoScreen.js
+++ b/src/screens/AlgoScreen.js
@@ -1,6 +1,6 @@
 import '../css/AlgoScreen.css';
 import '../css/App.css';
-import { BsFillSunFill, BsMoonFill } from 'react-icons/bs';
+import { BsFileEarmarkCodeFill, BsFillSunFill, BsMoonFill } from 'react-icons/bs';
 import AnimationManager from '../anim/AnimationMain';
 import Footer from '../components/Footer';
 import Header from '../components/Header';
@@ -114,6 +114,13 @@ class AlgoScreen extends React.Component {
 									<MdMenuBook onClick={this.toggleExamples} />
 								</IconContext.Provider>
 							)}
+							<div id="pseudocodeToggle">
+								<BsFileEarmarkCodeFill
+									size={31}
+									onClick={this.togglePseudocode}
+									color="black"
+								/>
+							</div>
 						</div>
 
 						<div className="viewport">
@@ -146,6 +153,8 @@ class AlgoScreen extends React.Component {
 	}
 
 	toggleExamples = () => this.setState(state => ({ examplesEnabled: !state.examplesEnabled }));
+
+	togglePseudocode = () => this.animManag.toggleLayer(32);
 }
 
 AlgoScreen.propTypes = {

--- a/src/screens/AlgoScreen.js
+++ b/src/screens/AlgoScreen.js
@@ -4,9 +4,7 @@ import { BsBookHalf, BsFileEarmarkCodeFill, BsFillSunFill, BsMoonFill } from 're
 import AnimationManager from '../anim/AnimationMain';
 import Footer from '../components/Footer';
 import Header from '../components/Header';
-import { IconContext } from 'react-icons';
 import { Link } from 'react-router-dom';
-import { MdMenuBook } from 'react-icons/md';
 import PropTypes from 'prop-types';
 import React from 'react';
 import ReactGA from 'react-ga4';
@@ -26,7 +24,7 @@ class AlgoScreen extends React.Component {
 			examplesEnabled: false,
 			width: 0,
 			theme: 'light',
-			pseudocodeEnabled: false,
+			pseudocodeEnabled: true,
 		};
 		ReactGA.send({ hitType: 'pageview', page: algoName });
 	}


### PR DESCRIPTION
Closes #291

All animated objects are drawn on certain "layers" on the canvas. With these changes, the pseudocode is drawn on its own layer that can be toggled on/off with a React button.

- By default the pseudocode is shown, mainly since this is what users are used to by now and the button to activate the code may not be super apparent.
- Code is drawn on layer '32' just for fun 😄, but this layer is now reserved exclusively for pseudocode 
- Changed appearance of example modal button to match code toggle: both buttons are theme dependent and show when they are active/inactive.

https://github.com/RodrigoDLPontes/visualization-tool/assets/67525591/917939a2-210b-4281-a627-39730a8949e8

https://github.com/RodrigoDLPontes/visualization-tool/assets/67525591/21795968-57b4-4eb7-a8da-be2693fa4eea
