### PR TITLE
fix font loading issue

### DIFF
--- a/src/anim/AnimatedLabel.js
+++ b/src/anim/AnimatedLabel.js
@@ -45,6 +45,33 @@ export default class AnimatedLabel extends AnimatedObject {
 		this.leftWidth = -1;
 		this.centerWidth = -1;
 		this.highlightIndex = -1;
+		this.fontLoaded = false;
+		if (isCode) {
+			this.loadFont();
+		}
+	}
+
+	async loadFont() {
+		const font = new FontFace('Source Code Pro', 'url(/SourceCodePro-Regular.ttf)', {
+			display: 'swap',
+		});
+
+		try {
+			await font.load();
+			document.fonts.add(font);
+			this.fontLoaded = true;
+			this.redraw();
+		} catch (error) {
+			console.error('Font could not be loaded:', error);
+			this.fontLoaded = false;
+		}
+	}
+
+	redraw() {
+		// Redraw method to be called when the font is loaded
+		const canvas = document.getElementById('canvas');
+		const context = canvas.getContext('2d');
+		this.draw(context);
 	}
 
 	centered() {
@@ -52,17 +79,9 @@ export default class AnimatedLabel extends AnimatedObject {
 	}
 
 	draw(context) {
-		if (!this.addedToScene) return;
+		if (!this.addedToScene || (this.isCode && !this.fontLoaded)) return;
 
 		context.globalAlpha = this.alpha;
-
-		const font = new FontFace('Source Code Pro', 'url(/SourceCodePro-Regular.ttf)');
-		font.load().then(
-			() => {
-				document.fonts.add(font);
-			},
-			() => {},
-		);
 
 		if (this.isCode) {
 			context.font = '13px "Source Code Pro", monospace';


### PR DESCRIPTION
Addresses #243

The issue was that the label wasn't waiting for the font to load before it was drawn, causing it to be rendered with the default font on first page load. This update should address that issue by adding a new async function that is called only when using the source code font.