### PR TITLE
Increase NODE_SPACING from 3 to 15

### DIFF
--- a/src/algo/BTree.js
+++ b/src/algo/BTree.js
@@ -44,7 +44,7 @@ const PRINT_HORIZONTAL_GAP = 50;
 const MIN_MAX_DEGREE = 4;
 
 const HEIGHT_DELTA = 50;
-const NODE_SPACING = 3;
+const NODE_SPACING = 15;
 const STARTING_Y = 30;
 const WIDTH_PER_ELEM = 40;
 const NODE_HEIGHT = 20;


### PR DESCRIPTION
The spacing of nodes on the 2-4 tree is very small, making it difficult to distinguish between different nodes. This pull request simply changes the NODE_SPACING variable from 3 to 15, increasing the gap and making it easier to visualize the tree.

The difference can be seen in the pictures below:

**Before**
![image](https://github.com/RodrigoDLPontes/visualization-tool/assets/35268332/816cbbaa-9a9f-4712-9ba2-c0743fcbf766)

**After**
![image](https://github.com/RodrigoDLPontes/visualization-tool/assets/35268332/12be48a2-2402-426d-bd51-9121c2bacbd8)